### PR TITLE
Initial work for creating/editing integrations

### DIFF
--- a/src/app/approuting/approuting.module.ts
+++ b/src/app/approuting/approuting.module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
   { path: 'dashboard', loadChildren: '../dashboard/dashboard.module#DashboardModule', canActivate: [AuthGuard] },
   { path: 'integrations', loadChildren: '../integrations/integrations.module#IntegrationsModule', canActivate: [AuthGuard] },
   { path: 'templates', loadChildren: '../templates/templates-routes.module#TemplateRoutesModule', canActivate: [AuthGuard] },
-  { path: 'connections', loadChildren: '../connections/connections.module#ConnectionsModule', canActivate: [AuthGuard] },
+  { path: 'connections', loadChildren: '../connections/connections-routes.module#ConnectionsRoutesModule', canActivate: [AuthGuard] },
 ];
 
 @NgModule({

--- a/src/app/connections/connections-routes.module.ts
+++ b/src/app/connections/connections-routes.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { ConnectionsModule } from './connections.module';
+import { ConnectionsListPage } from './list-page/list-page.component';
+import { ConnectionViewPage } from './view-page/view-page.component';
+
+const routes: Routes = [
+  { path: '', component: ConnectionsListPage, pathMatch: 'full' },
+  { path: ':id', component: ConnectionViewPage, pathMatch: 'full' },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes),
+    ConnectionsModule,
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class ConnectionsRoutesModule { }
+
+

--- a/src/app/connections/connections.module.ts
+++ b/src/app/connections/connections.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { RouterModule, Routes } from '@angular/router';
+import { RouterModule } from '@angular/router';
 
 import { IPaaSCommonModule } from '../common/common.module';
 import { ConnectionsListPage } from './list-page/list-page.component';
@@ -12,17 +12,12 @@ import { ConnectionViewWrapperComponent } from './view-wrapper/view-wrapper.comp
 import { ConnectionViewToolbarComponent } from './view-toolbar/view-toolbar.component';
 import { ConnectionViewComponent } from './view/view.component';
 
-const routes: Routes = [
-  { path: '', component: ConnectionsListPage, pathMatch: 'full' },
-  { path: ':id', component: ConnectionViewPage, pathMatch: 'full' },
-];
-
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
-    RouterModule.forChild(routes),
-    IPaaSCommonModule,
+    RouterModule,
+    IPaaSCommonModule
   ],
   declarations: [
     ConnectionsListPage,
@@ -33,6 +28,11 @@ const routes: Routes = [
     ConnectionViewToolbarComponent,
     ConnectionViewComponent,
   ],
+  exports: [
+    ConnectionsListToolbarComponent,
+    ConnectionsListComponent,
+    ConnectionViewToolbarComponent,
+    ConnectionViewComponent,
+  ]
 })
-export class ConnectionsModule {
-}
+export class ConnectionsModule { }

--- a/src/app/integrations/create-page/configure-connection/configure-connection.component.html
+++ b/src/app/integrations/create-page/configure-connection/configure-connection.component.html
@@ -1,0 +1,1 @@
+<p>configure connection</p>

--- a/src/app/integrations/create-page/configure-connection/configure-connection.component.ts
+++ b/src/app/integrations/create-page/configure-connection/configure-connection.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'ipaas-integrations-configure-connection',
+  templateUrl: 'configure-connection.component.html'
+})
+export class IntegrationsConfigureConnectionComponent implements OnInit {
+  constructor() { }
+
+  ngOnInit() { }
+}

--- a/src/app/integrations/create-page/create-page.component.html
+++ b/src/app/integrations/create-page/create-page.component.html
@@ -1,3 +1,20 @@
 <div class="integrations create">
-  <h1>Create an Integration</h1>
+  <div class="wizard-pf-row">
+    <div class="wizard-pf-sidebar">
+      <ipaas-integrations-flow-view 
+        [integration]="integration"></ipaas-integrations-flow-view>
+    </div>
+    <div class="wizard-pf-main">
+      <ol class="breadcrumb">
+        <li><a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Dashboard</a></li>
+        <li class="active">Create an integration</li>
+      </ol>
+      <h1>Create an integration</h1>
+      <router-outlet></router-outlet>
+      <!-- Wizard Footer -->
+      <div class='wizard-pf-footer'>
+        <button type='button' class='btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss'>Cancel</button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/integrations/create-page/create-page.component.spec.ts
+++ b/src/app/integrations/create-page/create-page.component.spec.ts
@@ -1,5 +1,18 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockBackend } from '@angular/http/testing';
+import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
+import { RestangularModule } from 'ng2-restangular';
+
+import { RouterModule } from '@angular/router';
+import { IPaaSCommonModule } from '../../common/common.module';
+import { FlowViewComponent } from './flow-view/flow-view.component';
+import { ConnectionsListComponent } from '../../connections/list/list.component';
+import { ConnectionsListToolbarComponent } from '../../connections/list-toolbar/list-toolbar.component';
+import { StoreModule } from '../../store/store.module';
 
 import { IntegrationsCreatePage } from './create-page.component';
 
@@ -9,7 +22,32 @@ describe('IntegrationsCreateComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [IntegrationsCreatePage],
+      imports: [
+        CommonModule,
+        FormsModule,
+        IPaaSCommonModule, 
+        StoreModule,
+        RouterTestingModule.withRoutes([]), 
+        RestangularModule.forRoot()
+      ],
+      declarations: [
+        IntegrationsCreatePage,
+        ConnectionsListComponent,
+        ConnectionsListToolbarComponent,
+        FlowViewComponent
+      ],
+      providers: [
+        MockBackend,
+        { 
+          provide: RequestOptions, 
+          useClass: BaseRequestOptions 
+        },
+        {
+          provide: Http, useFactory: (backend, options) => {
+            return new Http(backend, options);
+          }, deps: [MockBackend, RequestOptions],
+        },
+      ],      
     })
       .compileComponents();
   }));

--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -1,15 +1,42 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Params, Router } from '@angular/router'
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+
+import { IntegrationStore } from '../../store/integration/integration.store';
+import { Integration } from '../../store/integration/integration.model';
 
 @Component({
   selector: 'ipaas-integrations-create-page',
   templateUrl: './create-page.component.html',
   styleUrls: ['./create-page.component.scss'],
 })
-export class IntegrationsCreatePage implements OnInit {
+export class IntegrationsCreatePage implements OnInit, OnDestroy {
 
-  constructor() { }
+  integration: Observable<Integration>;
+  private readonly loading: Observable<boolean>;
+
+  subscription: Subscription;
+
+  constructor(private store: IntegrationStore,
+    private route: ActivatedRoute,
+    private router: Router) {
+    this.integration = this.store.resource;
+    this.loading = this.store.loading;
+  }
 
   ngOnInit() {
+    this.subscription = this.route.params.pluck<Params, string>('integrationId')
+      .map((integrationId:string) => this.store.loadOrCreate(integrationId))
+      .subscribe();
+    this.integration.subscribe((i:Integration) => {
+      console.log("Integration: ", i);
+      if (!i.steps || !i.steps.length || i.steps.length > 2) {
+        this.router.navigate(['connection-select', 1], { relativeTo: this.route });
+      }
+    });
   }
+
+  ngOnDestroy() { this.subscription.unsubscribe(); }
 
 }

--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router'
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -1,0 +1,59 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="form-group">
+      <p></p>
+      <input type="text" id="integrationName" class="form-control" placeholder="Enter integration name..." [ngModel]="i.name">
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-3">
+    <p>
+      <i class="fa fa-cube"></i>
+    </p>
+    <p>
+    </p>
+    <p>
+    </p>
+    <p>
+      <i class="fa fa-cube"></i>
+    </p>
+  </div>
+  <div class="col-md-9">
+    <div>
+      <h5>Start</h5>
+      <ul>
+        <li>
+          <i class="fa fa-chevron-down"></i> Set up this connection
+          <ul>
+            <li>
+              Choose a connection
+            </li>
+            <li>
+              Configure the connection
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+    <div>
+      <h5>Finish</h5>
+      <ul>
+        <li>
+          <i class="fa fa-chevron-right"></i> Set up this connection
+          <ul>
+            <li></li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>  
+</div>
+<!-- debug -->
+<!--
+<div class="row">
+  <div class="col-md-12">
+    <pre>{{integration | json}}</pre>
+  </div>
+</div>
+-->

--- a/src/app/integrations/create-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { Integration } from '../../../store/integration/integration.model';
+
+@Component({
+  selector: 'ipaas-integrations-flow-view',
+  templateUrl: './flow-view.component.html',
+  styleUrls: ['./flow-view.component.scss']
+})
+export class FlowViewComponent implements OnInit {
+
+  @Input() integration: Observable<Integration>;
+  i: Integration;
+
+  ngOnInit() {
+    this.integration.subscribe((integration) => {
+      this.i = integration;
+    });
+  }
+
+}

--- a/src/app/integrations/create-page/select-connection/select-connection.component.html
+++ b/src/app/integrations/create-page/select-connection/select-connection.component.html
@@ -1,0 +1,3 @@
+<p>Choose a connection to start</p>
+<ipaas-connections-list-toolbar></ipaas-connections-list-toolbar>
+<ipaas-connections-list [connections]="connections | async" [loading]="loading | async"></ipaas-connections-list>

--- a/src/app/integrations/create-page/select-connection/select-connection.component.ts
+++ b/src/app/integrations/create-page/select-connection/select-connection.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { ConnectionStore } from '../../../store/connection/connection.store';
+import { Connections } from '../../../store/connection/connection.model';
+
+@Component({
+  moduleId: module.id,
+  selector: 'ipaas-integrations-select-connection',
+  templateUrl: 'select-connection.component.html'
+})
+export class IntegrationsSelectConnectionComponent implements OnInit {
+
+  connections: Observable<Connections>;
+  loading: Observable<boolean>;
+
+  constructor(private store: ConnectionStore) {
+    this.loading = store.loading;
+    this.connections = store.list;
+  }
+
+  ngOnInit() {
+    this.store.loadAll();
+  }
+}

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -2,33 +2,54 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
+import { TabsModule } from 'ng2-bootstrap';
 
+import { IntegrationsCreatePage } from './create-page/create-page.component';
+import { IntegrationsSelectConnectionComponent } from './create-page/select-connection/select-connection.component';
+import { IntegrationsConfigureConnectionComponent } from './create-page/configure-connection/configure-connection.component';
 import { IntegrationsListPage } from './list-page/list-page.component';
 import { IntegrationsListToolbarComponent } from './list-toolbar/list-toolbar.component';
 import { IntegrationsFilterPipe } from './integrations-filter.pipe';
 import { IntegrationsListComponent } from './list/list.component';
-import { IntegrationsCreatePage } from './create-page/create-page.component';
+import { FlowViewComponent } from './create-page/flow-view/flow-view.component';
 import { IPaaSCommonModule } from '../common/common.module';
+import { ConnectionsModule } from '../connections/connections.module';
 
 const routes: Routes = [
   { path: '', component: IntegrationsListPage, pathMatch: 'full' },
-  { path: 'create', component: IntegrationsCreatePage, pathMatch: 'full' },
 ];
+
+// Set up routes for creating and editing using the same controllers
+['create', 'edit/:integrationId'].forEach((route) => {
+  routes.push({ 
+    path: route, 
+    component: IntegrationsCreatePage, 
+    children: [
+      { path: 'connection-select/:connectionId', component: IntegrationsSelectConnectionComponent },
+      { path: 'connection-configure/:connectionId', component: IntegrationsConfigureConnectionComponent },
+    ]
+  });
+});
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     RouterModule.forChild(routes),
+    ConnectionsModule,
+    TabsModule,
     IPaaSCommonModule,
   ],
   declarations: [
+    IntegrationsCreatePage,
+    IntegrationsSelectConnectionComponent,
+    IntegrationsConfigureConnectionComponent,
     IntegrationsListPage,
     IntegrationsListToolbarComponent,
     IntegrationsListComponent,
     IntegrationsFilterPipe,
-    IntegrationsCreatePage,
-  ],
+    FlowViewComponent,
+  ]
 })
 export class IntegrationsModule {
 }

--- a/src/app/integrations/list/list.component.html
+++ b/src/app/integrations/list/list.component.html
@@ -13,7 +13,7 @@
             </button>
           <ul class='dropdown-menu dropdown-menu-right' aria-labelledby='dropdownKebabRight9'>
             <li>
-              <a>Edit</a>
+              <a [routerLink]=" ['edit', integration.id] ">Edit</a>
             </li>
             <li>
               <a>Deactivate</a>

--- a/src/app/integrations/list/list.component.spec.ts
+++ b/src/app/integrations/list/list.component.spec.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
@@ -12,7 +13,10 @@ describe('IntegrationsListComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [IPaaSCommonModule],
+      imports: [
+        IPaaSCommonModule,
+        RouterTestingModule.withRoutes([]),
+      ],
       declarations: [IntegrationsListComponent],
     })
       .compileComponents();

--- a/src/app/store/entity/entity.model.ts
+++ b/src/app/store/entity/entity.model.ts
@@ -1,1 +1,5 @@
-export interface BaseEntity { readonly id?: string; }
+export interface BaseEntity { 
+  readonly id?: string; 
+  // TODO we'll make this optional for now
+  kind?: string;
+}

--- a/src/app/store/integration/integration.model.ts
+++ b/src/app/store/integration/integration.model.ts
@@ -2,8 +2,12 @@ import { Moment } from 'moment';
 
 import { BaseEntity } from '../entity/entity.model';
 
+export interface Step extends BaseEntity {
+  configuredProperties: Map<string, any>;
+}
+
 export interface Integration extends BaseEntity {
-  configuredProperties: Map<string, string>;
+  configuredProperties: Map<string, any>;
   createdBy: string;
   createdOn: Moment;
   description: string;
@@ -11,8 +15,7 @@ export interface Integration extends BaseEntity {
   modifiedBy: string;
   modifiedOn: Moment;
   name: string;
-  position: string;
-  type: string;
+  steps: Array<Step>;
 }
 
 export type Integrations = Array<Integration>;

--- a/src/app/store/integration/integration.store.ts
+++ b/src/app/store/integration/integration.store.ts
@@ -11,4 +11,21 @@ export class IntegrationStore extends AbstractStore<Integration, Integrations, I
   }
 
   protected get kind() { return 'Integration'; }
+
+  newInstance():Integration {
+    return <Integration> {
+          id: undefined,
+          createdBy: undefined,
+          createdOn: undefined,
+          description: undefined,
+          icon: undefined,
+          modifiedBy: undefined,
+          modifiedOn: undefined,
+          name: '',
+          kind: 'integration',
+          configuredProperties: <Map<string, string>>{},
+          steps: []
+        };
+  }
+
 }


### PR DESCRIPTION
Most work has been figuring out the routing and re-using components from connections to implement the designs.  No styling work has been done, so excuse the look of the screenshot(s), I kinda sorta started using the patternfly classes for the wizard pattern, but the design doesn't really match that pattern 100%.  Anyways, this was more about just getting elements on the page, not necessarily where they need to be :-)

And the difference between the two is subtle, look at the URL and also the `name` field at the top-left

via `Create Integration` link:

![via-create-link](https://cloud.githubusercontent.com/assets/351660/22753666/ef6bd020-ee0a-11e6-8c97-2f692f57bc82.PNG)

via clicking the `Edit` link from the list of integrations:

![via-edit-link](https://cloud.githubusercontent.com/assets/351660/22753687/03d8ec28-ee0b-11e6-8ea2-3677ced559db.PNG)

Other changes (yes, there's lots of 'em)

* refactored out routing in the connections module to use a separate routing module.
* create a 'flow-view' component
* Add wrapper pages in the integration module for selecting and showing connections
* Change the stores so that they only provide the returned data, not a restangularized object, as updates to objects should always be via the relevant data store.

I'll apologize in advance for the merge commits, I had forgotten to configure my git locally to rebase by default.

TODO
* will probably rename `create-page` to something else
* will likely move directories under `create-page` around
* wire stuff up