### PR TITLE
Add logging API for views

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+node {
+  ws {
+    checkout scm
+    withMaven(
+      maven: 'Maven 3.3.9',
+
+      // Run the maven build
+      sh "mvn clean install"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "rxjs": "^5.0.3",
     "tether": "^1.4.0",
     "ts-helpers": "^1.1.2",
+    "typescript-logging": "0.2.0-beta5",
     "zone.js": "^0.7.5"
   },
   "devDependencies": {

--- a/src/app/config.service.ts
+++ b/src/app/config.service.ts
@@ -6,6 +6,10 @@ import * as _ from 'lodash';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/toPromise';
 
+import { log, getCategory } from './logging';
+
+const category = getCategory('ConfigService');
+
 const defaults = Object.freeze({
   apiEndpoint: 'http://localhost:8080/v1',
   title: 'Red Hat iPaaS',
@@ -34,6 +38,7 @@ export class ConfigService {
     return this._http.get(configJson).map(res => res.json())
       .toPromise()
       .then((config) => {
+        log.infoc(() => 'Received config: ' + JSON.stringify(config, undefined, 2), category);
         this.settingsRepository = Object.freeze(_.merge({}, this.settingsRepository, config));
         return this;
       })

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -1,0 +1,24 @@
+import { Category, CategoryLogger, CategoryServiceFactory, CategoryDefaultConfiguration, LogLevel } from 'typescript-logging';
+
+// TODO typescript-logging will support a console API to change this at runtime in the future, for now we'll use localStorage
+const storedLogLevel = localStorage.getItem('logLevel');
+const logLevel = LogLevel[storedLogLevel] || LogLevel.Info;
+
+// default configuration
+CategoryServiceFactory.setDefaultConfiguration(new CategoryDefaultConfiguration(logLevel));
+
+const rootCategory = new Category('root');
+const categories = {};
+
+// files/modules can import this function to create their own logging category
+export function getCategory(name:string) {
+  if (name in categories) {
+    return categories[name];
+  } else {
+    categories[name] = new Category(name, rootCategory);
+    return categories[name];
+  }
+}
+
+// files should import this logger instance
+export const log: CategoryLogger = CategoryServiceFactory.getLogger(rootCategory);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,6 +1646,12 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
+  dependencies:
+    stackframe "^0.3.1"
+
 es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
@@ -5042,7 +5048,7 @@ source-map@0.4.x, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@>=0.5.6, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.6, source-map@>=0.5.6, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -5116,6 +5122,35 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-generator@^1.0.7:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-1.1.0.tgz#36f6a920751a6c10f499a13c32cbb5f51a0b8b25"
+  dependencies:
+    stackframe "^1.0.2"
+
+stackframe@^0.3.1, stackframe@~0.3:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+
+stackframe@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.2.tgz#162245509c687d328b14f671dab8fdb755b1e1e8"
+
+stacktrace-gps@^2.4.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz#69c827e9d6d6f41cf438d7f195e2e3cbfcf28c44"
+  dependencies:
+    source-map "0.5.6"
+    stackframe "~0.3"
+
+stacktrace-js@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-1.3.1.tgz#67cab2589af5c417b962f7369940277bb3b6a18b"
+  dependencies:
+    error-stack-parser "^1.3.6"
+    stack-generator "^1.0.7"
+    stacktrace-gps "^2.4.3"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.0:
   version "1.3.1"
@@ -5471,6 +5506,12 @@ type-is@~1.6.13:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-logging@0.2.0-beta5:
+  version "0.2.0-beta5"
+  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.2.0-beta5.tgz#fddb66269e83f632e8c62dc187799b8bed9a5dce"
+  dependencies:
+    stacktrace-js "1.3.1"
 
 typescript@^2.1.5:
   version "2.1.5"


### PR DESCRIPTION
Hopefully we can then avoid having `console.log` statements in the code, I'm as guilty as anybody.

Opted to use typescript-logging which has a nice enough API and categories.  They don't yet support changing the log level at runtime, however I've added some code that checks local storage, so to set the log level you can do:

`localStorage.logLevel = 'Trace';`

in the developer console and refresh.  Logging defaults to `Info` currently, see the interface for `LogLevel` for possible values.

I've updated a couple files that had `console.log` statements.  More info [here](https://github.com/mreuvers/typescript-logging)