### PR TITLE
Rework connection list to trigger a selected event so parent component can control what to do

### DIFF
--- a/src/app/connections/list-page/list-page.component.html
+++ b/src/app/connections/list-page/list-page.component.html
@@ -1,4 +1,4 @@
 <div class='connections list'>
   <ipaas-connections-list-toolbar></ipaas-connections-list-toolbar>
-  <ipaas-connections-list [connections]="connections | async" [loading]="loading | async"></ipaas-connections-list>
+  <ipaas-connections-list [connections]="connections | async" [loading]="loading | async" (onSelected)="onSelected($event)"></ipaas-connections-list>
 </div>

--- a/src/app/connections/list-page/list-page.component.ts
+++ b/src/app/connections/list-page/list-page.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 
+import { log, getCategory } from '../../logging';
 import { ConnectionStore } from '../../store/connection/connection.store';
-import { Connections } from '../../store/connection/connection.model';
+import { Connections, Connection } from '../../store/connection/connection.model';
+
+const category = getCategory('Connections');
 
 @Component({
   selector: 'ipaas-connections-list-page',
@@ -15,13 +19,18 @@ export class ConnectionsListPage implements OnInit {
 
   loading: Observable<boolean>;
 
-  constructor(private store: ConnectionStore) {
+  constructor(private store: ConnectionStore,
+              private router: Router) {
     this.loading = store.loading;
     this.connections = store.list;
   }
 
   ngOnInit() {
     this.store.loadAll();
+  }
+
+  onSelected(connection:Connection) {
+    this.router.navigate(['connections', connection.id]);
   }
 
 }

--- a/src/app/connections/list/list.component.html
+++ b/src/app/connections/list/list.component.html
@@ -1,8 +1,8 @@
 <ipaas-loading [loading]="loading">
   <div class="container-cards-pf">
     <div class="row row-cards-pf">
-      <div class="col-xs-12 col-sm-3 col-md-2 card" *ngFor="let connection of connections">
-        <div class="card-pf card-pf-view card-pf-view-xs">
+      <div class="col-xs-12 col-sm-3 col-md-2 card" *ngFor="let connection of connections" (click)="onSelect(connection)">
+        <div class="card-pf card-pf-view card-pf-view-xs card-pf-view-select card-pf-view-single-select" [class.active]="isSelected(connection)">
           <div class="card-pf-body">
 
             <!-- Card Heading -->
@@ -34,7 +34,7 @@
 
               <h2 class="card-pf-title">
                 <span class="fa {{ connection.icon }}"></span>
-                <a [routerLink]="[connection.id]" class="card-title">{{ connection.name }}</a>
+                <a class="card-title">{{ connection.name }}</a>
               </h2>
             </div>
 

--- a/src/app/connections/list/list.component.ts
+++ b/src/app/connections/list/list.component.ts
@@ -1,6 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
-import { Connections } from '../../store/connection/connection.model';
+import { log, getCategory } from '../../logging';
+import { Connections, Connection } from '../../store/connection/connection.model';
+
+const category = getCategory('Connections');
 
 @Component({
   selector: 'ipaas-connections-list',
@@ -10,11 +13,22 @@ import { Connections } from '../../store/connection/connection.model';
 export class ConnectionsListComponent {
 
   truncateLimit = 80;
-
   truncateTrail = '…';
+  selectedId = undefined;
 
   @Input() connections: Connections;
-
   @Input() loading: boolean;
+  @Output() onSelected: EventEmitter<Connection> = new EventEmitter();
+
+  onSelect(connection:Connection) {
+    log.debugc(() => "Selected connection (list): " + connection.name, category);
+    this.selectedId = connection.id;
+    this.onSelected.emit(connection);
+  }
+
+  isSelected(connection:Connection) {
+    return connection.id == this.selectedId;
+  }
+
 
 }

--- a/src/app/integrations/create-page/select-connection/select-connection.component.html
+++ b/src/app/integrations/create-page/select-connection/select-connection.component.html
@@ -1,3 +1,3 @@
 <p>Choose a connection to start</p>
 <ipaas-connections-list-toolbar></ipaas-connections-list-toolbar>
-<ipaas-connections-list [connections]="connections | async" [loading]="loading | async"></ipaas-connections-list>
+<ipaas-connections-list [connections]="connections | async" [loading]="loading | async" (onSelected)="onSelected($event)"></ipaas-connections-list>

--- a/src/app/integrations/create-page/select-connection/select-connection.component.ts
+++ b/src/app/integrations/create-page/select-connection/select-connection.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
+import { log, getCategory } from '../../../logging';
 import { ConnectionStore } from '../../../store/connection/connection.store';
-import { Connections } from '../../../store/connection/connection.model';
+import { Connections, Connection } from '../../../store/connection/connection.model';
+
+const category = getCategory("Integrations");
 
 @Component({
   moduleId: module.id,
@@ -17,6 +20,10 @@ export class IntegrationsSelectConnectionComponent implements OnInit {
   constructor(private store: ConnectionStore) {
     this.loading = store.loading;
     this.connections = store.list;
+  }
+
+  onSelected(connection:Connection) {
+    log.debugc(() => "Selected connection: " + connection.name, category);
   }
 
   ngOnInit() {


### PR DESCRIPTION
This allows the create integration page to re-use the connection list for selecting connections.

Ultimately we'll need to sort having a kebab drop-down within the clickable connection element, an issue we've handled before [this way](https://github.com/redhat-ipaas/ipaas-ui/blob/master-original/src/app/%2Bconnections/library/library.component.ts#L85-L87), though maybe if we use ngClick instead to trigger the drop-down we wouldn't have to resort to that workaround.