### PR TITLE
[relates #52] Fix SpecReporter require in protractor config

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,7 @@
 // https://github.com/angular/protractor/blob/master/docs/referenceConf.js
 
 /*global jasmine */
-var SpecReporter = require('jasmine-spec-reporter');
+var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
   allScriptsTimeout: 11000,

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,7 @@
 // https://github.com/angular/protractor/blob/master/docs/referenceConf.js
 
 /*global jasmine */
-var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+let SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
   allScriptsTimeout: 11000,


### PR DESCRIPTION
According to lathonez/clicker#205 there was api break in SpecReporter 3.

With this change I'm able to run `yarn e2e`, but the tests will fail anyway, because browser is redirected to github for oAuth.