### PR TITLE
Add a service for the current integration, use events to communicate between views

### DIFF
--- a/src/app/integrations/create-page/configure-connection/configure-connection.component.html
+++ b/src/app/integrations/create-page/configure-connection/configure-connection.component.html
@@ -1,1 +1,2 @@
 <p>configure connection</p>
+<pre>{{ connection | json}}</pre>

--- a/src/app/integrations/create-page/configure-connection/configure-connection.component.ts
+++ b/src/app/integrations/create-page/configure-connection/configure-connection.component.ts
@@ -1,11 +1,54 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+
+import { CurrentFlow, FlowEvent } from '../current-flow.service';
+import { Connection } from '../../../store/connection/connection.model';
 
 @Component({
   selector: 'ipaas-integrations-configure-connection',
   templateUrl: 'configure-connection.component.html',
 })
-export class IntegrationsConfigureConnectionComponent implements OnInit {
-  constructor() { }
+export class IntegrationsConfigureConnectionComponent implements OnInit, OnDestroy {
 
-  ngOnInit() { }
+  flowSubscription: Subscription;
+  routeSubscription: Subscription;
+  position: number;
+  connection: Connection = <Connection>{ };
+
+  constructor(
+    private currentFlow: CurrentFlow,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {
+
+  }
+
+  handleFlowEvent(event: FlowEvent) {
+    switch (event.kind) {
+      case 'integration-no-connection':
+        break;
+    }
+  }
+
+  ngOnInit() {
+    this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
+      this.handleFlowEvent(event);
+    });
+    this.routeSubscription = this.route.params.pluck<Params, string>('position')
+      .map((position: string) => {
+        this.position = Number.parseInt(position);
+        this.connection = <Connection>this.currentFlow.integration.steps[this.position];
+        this.currentFlow.events.emit({
+          kind: 'integration-connection-configure',
+          position: this.position,
+        });
+      })
+      .subscribe();
+  }
+
+  ngOnDestroy() {
+    this.routeSubscription.unsubscribe();
+    this.flowSubscription.unsubscribe();
+  }
 }

--- a/src/app/integrations/create-page/create-page.component.html
+++ b/src/app/integrations/create-page/create-page.component.html
@@ -1,8 +1,7 @@
 <div class="integrations create">
   <div class="wizard-pf-row">
     <div class="wizard-pf-sidebar">
-      <ipaas-integrations-flow-view 
-        [integration]="integration"></ipaas-integrations-flow-view>
+      <ipaas-integrations-flow-view></ipaas-integrations-flow-view>
     </div>
     <div class="wizard-pf-main">
       <ol class="breadcrumb">
@@ -13,7 +12,10 @@
       <router-outlet></router-outlet>
       <!-- Wizard Footer -->
       <div class='wizard-pf-footer'>
-        <button type='button' class='btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss'>Cancel</button>
+        <button type='button' class='btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss' (click)="cancel()">Cancel</button>
+        <button type="button" class="btn btn-primary" [disabled]="!canContinue" (click)="continue()" *ngIf="!(getCurrentChild() === 'connection-configure' && position === 1)">Next</button>
+        <!-- TODO hiding showing hack -->        
+        <button type="button" class="btn btn-primary" *ngIf="getCurrentChild() === 'connection-configure' && position === 1" (click)="finish()">Finish</button>
       </div>
     </div>
   </div>

--- a/src/app/integrations/create-page/create-page.component.spec.ts
+++ b/src/app/integrations/create-page/create-page.component.spec.ts
@@ -13,6 +13,7 @@ import { FlowViewComponent } from './flow-view/flow-view.component';
 import { ConnectionsListComponent } from '../../connections/list/list.component';
 import { ConnectionsListToolbarComponent } from '../../connections/list-toolbar/list-toolbar.component';
 import { StoreModule } from '../../store/store.module';
+import { CurrentFlow } from './current-flow.service';
 
 import { IntegrationsCreatePage } from './create-page.component';
 
@@ -47,6 +48,7 @@ describe('IntegrationsCreateComponent', () => {
             return new Http(backend, options);
           }, deps: [MockBackend, RequestOptions],
         },
+        CurrentFlow,
       ],
     })
       .compileComponents();

--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
 import { IntegrationStore } from '../../store/integration/integration.store';
 import { Integration } from '../../store/integration/integration.model';
-
+import { CurrentFlow, FlowEvent } from './current-flow.service';
 import { log, getCategory } from '../../logging';
 
 const category = getCategory('IntegrationsCreatePage');
@@ -20,27 +20,96 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
   integration: Observable<Integration>;
   private readonly loading: Observable<boolean>;
 
-  subscription: Subscription;
+  integrationSubscription: Subscription;
+  routeSubscription: Subscription;
+  childRouteSubscription: Subscription;
+  flowSubscription: Subscription;
+  urls: UrlSegment[];
+  canContinue = false;
+  position: number;
 
-  constructor(private store: IntegrationStore,
+  constructor(
+    private currentFlow: CurrentFlow,
+    private store: IntegrationStore,
     private route: ActivatedRoute,
-    private router: Router) {
+    private router: Router,
+    ) {
     this.integration = this.store.resource;
     this.loading = this.store.loading;
   }
 
+  cancel() {
+    this.router.navigate(['/integrations']);
+  }
+
+  finish() {
+    this.router.navigate(['/integrations']);
+  }
+
+  continue() {
+    const child = this.getCurrentChild();
+    switch (child) {
+      case 'connection-select':
+        this.router.navigate(['connection-configure', this.position], { relativeTo: this.route });
+        break;
+      case 'connection-configure':
+        // TODO hard-coding this to just go to the next connection
+        this.router.navigate(['connection-select', this.position + 1], { relativeTo: this.route });
+        break;
+      default:
+        // who knows...
+        break;
+    }
+  }
+
+  getCurrentChild(): string {
+    const child = this.route.firstChild;
+    if (child && child.snapshot) {
+      const path = child.snapshot.url;
+      // log.debugc(() => 'path from root: ' + path, category);
+      return path[0].path;
+    } else {
+      // log.debugc(() => 'no current child', category);
+      return undefined;
+    }
+  }
+
+  handleFlowEvent(event: FlowEvent) {
+    const child = this.getCurrentChild();
+    switch (event.kind) {
+      case 'integration-no-connections':
+        if (child !== 'connection-select') {
+          this.router.navigate(['connection-select', 0], { relativeTo: this.route });
+        }
+        break;
+      case 'integration-selected-connection':
+        this.position = event['position'];
+        this.currentFlow.events.emit({
+          kind: 'integration-set-connection',
+          position: this.position,
+          connection: event['connection'],
+        });
+        this.canContinue = true;
+        break;
+    }
+  }
+
   ngOnInit() {
-    this.subscription = this.route.params.pluck<Params, string>('integrationId')
+    this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
+      this.handleFlowEvent(event);
+    });
+    this.routeSubscription = this.route.params.pluck<Params, string>('integrationId')
       .map((integrationId: string) => this.store.loadOrCreate(integrationId))
       .subscribe();
-    this.integration.subscribe((i: Integration) => {
-      log.debugc(() => 'Integration: ' + JSON.stringify(i, null, 2), category);
-      if (!i.steps || !i.steps.length || i.steps.length > 2) {
-        this.router.navigate(['connection-select', 1], { relativeTo: this.route });
-      }
+    this.integrationSubscription = this.integration.subscribe((i: Integration) => {
+      this.currentFlow.integration = i;
     });
   }
 
-  ngOnDestroy() { this.subscription.unsubscribe(); }
+  ngOnDestroy() {
+    this.integrationSubscription.unsubscribe();
+    this.routeSubscription.unsubscribe();
+    this.flowSubscription.unsubscribe();
+  }
 
 }

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, EventEmitter } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+
+import { Integration } from '../../store/integration/integration.model';
+import { log, getCategory } from '../../logging';
+
+const category = getCategory('CurrentFlow');
+
+export class FlowEvent {
+  kind: string;
+  [name: string]: any;
+}
+
+@Injectable()
+export class CurrentFlow {
+
+  private _integration: Integration;
+  private subscription: Subscription;
+
+  events = new EventEmitter<FlowEvent>();
+
+  constructor() {
+    this.subscription = this.events.subscribe((event: FlowEvent) => this.handleEvent(event));
+  }
+
+  handleEvent(event: FlowEvent) {
+    log.debugc(() => 'event: ' + JSON.stringify(event, undefined, 2), category);
+    switch (event.kind) {
+      case 'integration-set-connection':
+      if (!this._integration.steps) {
+        this._integration.steps = [];
+      }
+      const position = +event['position'];
+      const connection = event['connection'];
+      this._integration.steps[position] = connection;
+      log.debugc(() => 'Set connection ' + connection.name + ' at position: ' + position, category);
+      break;
+    }
+    log.debugc(() => 'integration: ' + JSON.stringify(this._integration, undefined, 2), category);
+  }
+
+  get integration() {
+    return this._integration;
+  }
+
+  set integration(i: Integration) {
+    this._integration = i;
+    log.debugc(() => 'Integration reset for current flow', category);
+    this.events.emit({
+      kind: 'integration-updated',
+      integration: this._integration,
+    });
+    if (!i.steps || !i.steps.length) {
+      log.debugc(() => 'Integration has no steps, assuming it\'s new', category);
+      this.events.emit({
+        kind: 'integration-no-connections',
+      });
+    }
+  }
+
+
+}

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -27,10 +27,10 @@
           <i class="fa fa-chevron-down"></i> Set up this connection
           <ul>
             <li>
-              Choose a connection
+              <span [class]="getClass('connection-select', 0)">Choose a connection</span>
             </li>
             <li>
-              Configure the connection
+              <span [class]="getClass('connection-configure', 0)">Configure the connection</span>              
             </li>
           </ul>
         </li>
@@ -40,9 +40,14 @@
       <h5>Finish</h5>
       <ul>
         <li>
-          <i class="fa fa-chevron-right"></i> Set up this connection
+          <i class="fa fa-chevron-down"></i> Set up this connection
           <ul>
-            <li></li>
+            <li>
+              <span [class]="getClass('connection-select', 1)">Choose a connection</span>
+            </li>
+            <li>
+              <span [class]="getClass('connection-configure', 1)">Configure the connection</span>              
+            </li>                            
           </ul>
         </li>
       </ul>

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -1,0 +1,3 @@
+.bold {
+  font-weight: bold;
+}

--- a/src/app/integrations/create-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.ts
@@ -1,22 +1,68 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 
+import { log, getCategory } from '../../../logging';
+import { CurrentFlow, FlowEvent } from '../current-flow.service';
 import { Integration } from '../../../store/integration/integration.model';
+
+const category = getCategory('IntegrationsCreatePage');
 
 @Component({
   selector: 'ipaas-integrations-flow-view',
   templateUrl: './flow-view.component.html',
   styleUrls: ['./flow-view.component.scss'],
 })
-export class FlowViewComponent implements OnInit {
+export class FlowViewComponent implements OnInit, OnDestroy {
 
-  @Input() integration: Observable<Integration>;
-  i: Integration;
+  i: Integration = <Integration>{};
+  flowSubscription: Subscription;
+  childRouteSubscription: Subscription;
+  urls: UrlSegment[];
+  currentPosition: number;
+  currentState: string;
+
+  constructor(
+    private currentFlow: CurrentFlow,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {
+
+  }
+
+  getClass(state, position) {
+    if (state === this.currentState && position === this.currentPosition) {
+      return 'bold';
+    } else {
+      return '';
+    }
+  }
+
+  handleFlowEvent(event: FlowEvent) {
+    switch (event.kind) {
+      case 'integration-updated':
+        this.i = event['integration'];
+        break;
+      case 'integration-connection-select':
+        this.currentState = 'connection-select';
+        this.currentPosition = event['position'];
+        break;
+      case 'integration-connection-configure':
+        this.currentState = 'connection-configure';
+        this.currentPosition = event['position'];
+        break;
+    }
+  }
 
   ngOnInit() {
-    this.integration.subscribe((integration) => {
-      this.i = integration;
+    this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
+      this.handleFlowEvent(event);
     });
+  }
+
+  ngOnDestroy() {
+    this.flowSubscription.unsubscribe();
   }
 
 }

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -12,6 +12,7 @@ import { IntegrationsListToolbarComponent } from './list-toolbar/list-toolbar.co
 import { IntegrationsFilterPipe } from './integrations-filter.pipe';
 import { IntegrationsListComponent } from './list/list.component';
 import { FlowViewComponent } from './create-page/flow-view/flow-view.component';
+import { CurrentFlow } from './create-page/current-flow.service';
 import { IPaaSCommonModule } from '../common/common.module';
 import { ConnectionsModule } from '../connections/connections.module';
 
@@ -25,8 +26,8 @@ const routes: Routes = [
     path: route,
     component: IntegrationsCreatePage,
     children: [
-      { path: 'connection-select/:connectionId', component: IntegrationsSelectConnectionComponent },
-      { path: 'connection-configure/:connectionId', component: IntegrationsConfigureConnectionComponent },
+      { path: 'connection-select/:position', component: IntegrationsSelectConnectionComponent },
+      { path: 'connection-configure/:position', component: IntegrationsConfigureConnectionComponent },
     ],
   });
 });
@@ -49,6 +50,9 @@ const routes: Routes = [
     IntegrationsListComponent,
     IntegrationsFilterPipe,
     FlowViewComponent,
+  ],
+  providers: [
+    CurrentFlow,
   ],
 })
 export class IntegrationsModule {


### PR DESCRIPTION
Basically at least lets you click though some of the flow, i.e. picking a connection, viewing what ought to be the configuration form, then picking the end connection etc.

More work to do, going to bring in [this library](https://github.com/udos86/ng2-dynamic-forms) to render the configuration form for the connection which will replace the json in the second page.

More validation between steps is needed too, side-bar should eventually start being more dynamic.

Also still have to implement saving the integration.  Anyhoo, screencast of how it's looking:

![ezgif com-20910625b5](https://cloud.githubusercontent.com/assets/351660/22947127/dbcc5686-f2c7-11e6-9564-a10a8718f962.gif)


