### PR TITLE
Dynamically set page title, add back button, tweak connection selection

### DIFF
--- a/src/app/integrations/create-page/configure-connection/configure-connection.component.html
+++ b/src/app/integrations/create-page/configure-connection/configure-connection.component.html
@@ -1,4 +1,4 @@
-<p>configure connection</p>
+<p>Fill out the fields associated with the selected connection.</p>
 <div *ngIf="formGroup">
   <form [formGroup]="formGroup">
     <dynamic-form-bootstrap-control *ngFor="let controlModel of formModel"

--- a/src/app/integrations/create-page/create-page.component.html
+++ b/src/app/integrations/create-page/create-page.component.html
@@ -6,16 +6,17 @@
     <div class="wizard-pf-main">
       <ol class="breadcrumb">
         <li><a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Dashboard</a></li>
-        <li class="active">Create an Integration</li>
+        <li class="active">{{ pageTitle }}</li>
       </ol>
-      <h1>Create an integration</h1>
+      <h1>{{ pageTitle }}</h1>
       <router-outlet></router-outlet>
       <!-- Wizard Footer -->
       <div class='wizard-pf-footer'>
         <button type='button' class='btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss' (click)="cancel()">Cancel</button>
-        <button type="button" class="btn btn-primary" *ngIf="showNext()" [disabled]="!canContinue()" (click)="continue()" >Next</button>
+        <button type="button" class="btn btn-default" *ngIf="showBack()" (click)="goBack()"><i class="fa fa-chevron-left"></i> Back</button>        
+        <button type="button" class="btn btn-primary" *ngIf="showNext()" [disabled]="!canContinue()" (click)="continue()" >Next <i class="fa fa-chevron-right"></i></button>
         <!-- TODO hiding showing hack -->        
-        <button type="button" class="btn btn-primary" *ngIf="showFinish()" [disabled]="!canFinish()" (click)="finish()">Finish</button>
+        <button type="button" class="btn btn-primary" *ngIf="showFinish()" [disabled]="!canFinish()" (click)="finish()">Create</button>
       </div>
     </div>
   </div>

--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -27,6 +27,7 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
   urls: UrlSegment[];
   _canContinue = false;
   position: number;
+  pageTitle = 'Create an integration';
 
   constructor(
     private currentFlow: CurrentFlow,
@@ -43,7 +44,31 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
   }
 
   showNext() {
+    if (this.getCurrentChild() === 'connection-select') {
+      return false;
+    }
     return !(this.getCurrentChild() === 'connection-configure' && this.position === 1);
+  }
+
+  showBack() {
+    return this.getCurrentChild() === 'connection-configure';
+  }
+
+  goBack() {
+    const child = this.getCurrentChild();
+    switch (child) {
+      case 'connection-select':
+        // uh...
+        break;
+      case 'connection-configure':
+        // TODO hard-coding this to just go to the next connection
+        this.router.navigate(['connection-select', this.position], { relativeTo: this.route });
+        break;
+      default:
+        // who knows...
+        break;
+    }
+
   }
 
   showFinish() {
@@ -106,6 +131,14 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
         break;
       case 'integration-connection-select':
         this.position = event['position'];
+        if (this.position === 0 && this.currentFlow.isEmpty()) {
+          this.pageTitle = 'Create an integration';
+        } else if (this.currentFlow.atEnd(this.position)) {
+          this.pageTitle = 'Select end connection';
+        } else {
+          this.pageTitle = 'Add a connection';
+        }
+
         if (!this.currentFlow.integration.steps[this.position]) {
           this._canContinue = false;
         }
@@ -118,6 +151,14 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
           connection: event['connection'],
         });
         this._canContinue = true;
+        this.continue();
+        break;
+      case 'integration-connection-configure':
+        this.position = event['position'];
+        const connection = this.currentFlow.getStep(this.position);
+        if (connection) {
+          this.pageTitle = 'Configure ' + connection['name'];
+        }
         break;
     }
   }

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -31,13 +31,32 @@ export class CurrentFlow {
     return (this._integration.name && this._integration.name.length);
   }
 
+  private createSteps() {
+    if (!this._integration.steps) {
+      this._integration.steps = [];
+    }
+  }
+
+  getStep(position: number) {
+    this.createSteps();
+    return this._integration.steps[position];    
+  }
+
+  isEmpty() {
+    this.createSteps();
+    return this._integration.steps.length === 0; l;
+  }
+
+  atEnd(position: number) {
+    this.createSteps();
+    return position >= this._integration.steps.length;
+  }
+
   handleEvent(event: FlowEvent) {
     log.debugc(() => 'event: ' + JSON.stringify(event, undefined, 2), category);
     switch (event.kind) {
       case 'integration-set-connection':
-      if (!this._integration.steps) {
-        this._integration.steps = [];
-      }
+      this.createSteps();
       const position = +event['position'];
       const connection = event['connection'];
       this._integration.steps[position] = connection;


### PR DESCRIPTION
This PR ensures the page title in the integration editor matches the designs as you go through the wizard.

Also added the back button, though currently you can't go back once you've set the start connection currently.  Just shhh don't tell anybody that.

Also added chevrons and s/Finish/Create/ per the design.