### PR TITLE
Create an Integration UI Fixes

### DIFF
--- a/src/app/integrations/create-page/create-page.component.html
+++ b/src/app/integrations/create-page/create-page.component.html
@@ -8,7 +8,9 @@
         <li><a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Dashboard</a></li>
         <li class="active">{{ pageTitle }}</li>
       </ol>
-      <h1>{{ pageTitle }}</h1>
+      <div class="title">
+        <h1>{{ pageTitle }}</h1>
+      </div>
       <router-outlet></router-outlet>
       <!-- Wizard Footer -->
       <div class='wizard-pf-footer'>

--- a/src/app/integrations/create-page/create-page.component.scss
+++ b/src/app/integrations/create-page/create-page.component.scss
@@ -29,5 +29,10 @@
     top: 0;
     padding: 20px;
   }
+
+  .wizard-pf-footer {
+    background: #FFFFFF;
+    padding: 10px;
+  }
 }
 

--- a/src/app/integrations/create-page/create-page.component.scss
+++ b/src/app/integrations/create-page/create-page.component.scss
@@ -1,6 +1,21 @@
 .integrations.create {
   margin-left: -20px;
 
+  .title {
+    border-bottom: 1px solid #D7D6D7;
+    margin: auto -20px;
+    margin-bottom: 15px;
+
+    h1 {
+      padding: 0 20px;
+    }
+  }
+
+  // This does not get inherited by the directive
+  .toolbar-pf {
+    background: none;
+  }
+
   .wizard-pf-row {
     bottom: 0;
     overflow: hidden;
@@ -14,7 +29,7 @@
     margin-left: 325px;
     margin-right: -15px;
     overflow: auto;
-    padding: 3em;
+    padding: 15px 3em 3em 3em;
     vertical-align: top;
   }
 

--- a/src/app/integrations/create-page/create-page.component.scss
+++ b/src/app/integrations/create-page/create-page.component.scss
@@ -12,9 +12,11 @@
   }
 
   // This does not get inherited by the directive
+  /*
   .toolbar-pf {
     background: none;
   }
+  */
 
   .wizard-pf-row {
     bottom: 0;

--- a/src/app/integrations/create-page/create-page.component.scss
+++ b/src/app/integrations/create-page/create-page.component.scss
@@ -6,7 +6,7 @@
     overflow: hidden;
     position: absolute;
     top: 60px;
-    width: auto;
+    width: 100%;
   }
 
   .wizard-pf-main {

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -39,7 +39,7 @@ export class CurrentFlow {
 
   getStep(position: number) {
     this.createSteps();
-    return this._integration.steps[position];    
+    return this._integration.steps[position];
   }
 
   isEmpty() {

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -44,7 +44,7 @@ export class CurrentFlow {
 
   isEmpty() {
     this.createSteps();
-    return this._integration.steps.length === 0; l;
+    return this._integration.steps.length === 0;
   }
 
   atEnd(position: number) {

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -32,8 +32,8 @@
     
     <!-- Text Collapse Steps -->
     <div class="col-md-9 text">
-      <div>
-        <h5 class="start">Start</h5>
+      <div class="start">
+        <h5>Start</h5>
         <ul>
           <li (click)="startIsCollapsed = !startIsCollapsed">
             <i class="fa fa-chevron-down"></i> Set up this connection
@@ -50,18 +50,18 @@
           </li>
         </ul>
       </div>
-      <div>
-        <h5 class="finish">Finish</h5>
+      <div class="finish">
+        <h5>Finish</h5>
         <ul>
           <li (click)="finishIsCollapsed = !finishIsCollapsed">
             <i class="fa fa-chevron-down"></i> Set up this connection
             <ul (collapsed)="collapsed($event)"
                 (expanded)="expanded($event)"
                 [collapse]="finishIsCollapsed">
-              <li>
+              <li class="active">
                 <span [class]="getClass('connection-select', 1)">Choose a connection</span>
               </li>
-              <li>
+              <li class="inactive">
                 <span [class]="getClass('connection-configure', 1)">Configure the connection</span>
               </li>
             </ul>

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -1,24 +1,13 @@
 <div class="flow-view">
-  <div class="row search">
+  <div class="row name">
     <div class="col-md-12">
       <div class="form-group">
-        <p></p>
         <input type="text" id="integrationName" class="form-control" placeholder="Enter integration name..." [ngModel]="integrationName" (ngModelChange)="integrationNameChanged($event)">
       </div>
     </div>
   </div>
-  <!--
-  <button type="button" class="btn btn-primary"
-          (click)="isCollapsed = !isCollapsed">Toggle collapse
-  </button>
-  <hr>
-  <div (collapsed)="collapsed($event)"
-       (expanded)="expanded($event)"
-       [collapse]="isCollapsed"
-       class="card card-block card-header">
-    <div class="well well-lg">Some content</div>
-  </div>
-  -->
+  
+  <!-- Steps -->
   <div class="row steps">
     
     <!-- Cube Line -->
@@ -41,16 +30,16 @@
       </div>
     </div>
     
-    <!-- Dropdown -->
-    <div class="col-md-9">
+    <!-- Text Collapse Steps -->
+    <div class="col-md-9 text">
       <div>
         <h5 class="start">Start</h5>
         <ul>
-          <li (click)="isCollapsed = !isCollapsed">
+          <li (click)="startIsCollapsed = !startIsCollapsed">
             <i class="fa fa-chevron-down"></i> Set up this connection
             <ul (collapsed)="collapsed($event)"
                 (expanded)="expanded($event)"
-                [collapse]="isCollapsed">
+                [collapse]="startIsCollapsed">
               <li>
                 <span [class]="getClass('connection-select', 0)">Choose a connection</span>
               </li>
@@ -64,9 +53,11 @@
       <div>
         <h5 class="finish">Finish</h5>
         <ul>
-          <li>
+          <li (click)="finishIsCollapsed = !finishIsCollapsed">
             <i class="fa fa-chevron-down"></i> Set up this connection
-            <ul>
+            <ul (collapsed)="collapsed($event)"
+                (expanded)="expanded($event)"
+                [collapse]="finishIsCollapsed">
               <li>
                 <span [class]="getClass('connection-select', 1)">Choose a connection</span>
               </li>

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -1,4 +1,6 @@
 .flow-view {
+  width: 300px;
+
   ul {
     list-style-type: none;
     -webkit-margin-before: 0;
@@ -14,9 +16,10 @@
 
   // Integration Name Editor
   .name {
-    padding-bottom: 5px;
     border-bottom: 2px solid #D0D0D0;
+    font-style: italic;
     margin-top: -10px;
+    padding-bottom: 5px;
   }
 
   // Steps on left-hand side
@@ -74,16 +77,16 @@
 
     // Right-hand side collapsible text menu
     .text {
-      padding-right: 35px;
+      padding-right: 0;
       padding-top: 15px;
 
       ul {
         cursor: pointer;
-        //padding-right: 35px;
+        padding-right: 35px;
         -webkit-padding-start: 0;
 
         li {
-          padding-left: 5px;
+          //padding-left: 5px;
 
           &:hover {
             //background-color:
@@ -92,11 +95,38 @@
       }
 
       .start, .finish {
-        background-color: #EDEDED;
-        cursor: pointer;
-        display: inline;
-        padding: 5px;
-        text-transform: uppercase;
+        h5 {
+          background-color: #EDEDED;
+          cursor: pointer;
+          display: inline;
+          padding: 5px;
+          text-transform: uppercase;
+        }
+
+        ul {
+          min-width: 160px;
+          padding: 10px 0;
+
+          // Sub-Menu Items
+          &.collapse {
+            margin-top: 5px;
+            padding: 5px 0;
+
+            li {
+              padding: 5px 5px 5px 15px;
+
+              &.active {
+                background-color: #D6EEFA;
+                border-bottom: 1px solid #B8DFF3;
+                border-top: 1px solid #B8DFF3;
+              }
+
+              &.inactive {
+                color: #D1D1D1;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -12,25 +12,17 @@
     font-weight: bold;
   }
 
-  .cube {
-    .round {
-      -moz-border-radius: 100px;
-      border-radius: 100px;
-      padding: 7px;
-
-      &.active {
-        border: 3px solid #1487CB;
-      }
-
-      &.inactive {
-        border: 3px solid #D0D0D0;
-      }
-    }
+  // Integration Name Editor
+  .name {
+    padding-bottom: 5px;
+    border-bottom: 2px solid #D0D0D0;
+    margin-top: -10px;
   }
 
-  .search {}
-
+  // Steps on left-hand side
   .steps {
+    padding-top: 20px;
+
     ul {
       padding-right: 35px;
       -webkit-padding-start: 0;
@@ -40,29 +32,67 @@
       }
     }
 
+    // Left-hand side design with the cube and line
     .cube-line {
       text-align: center;
 
-      .fa.fa-cube {
-        color: #D1D1D1;
-        font-size: x-large;
+      // Used for the containing <div> around any cubes to make e2e testing easier
+      .cube {
+        // Overriding the actual cube icon's colors
+        .fa.fa-cube {
+          color: #D1D1D1;
+          font-size: x-large;
+        }
+
+        .round {
+          -moz-border-radius: 100px;
+          border-radius: 100px;
+          padding: 7px;
+
+          &.active {
+            border: 3px solid #1487CB;
+          }
+
+          &.inactive {
+            border: 3px solid #D0D0D0;
+          }
+        }
+      }
+
+      // Line that connects cubes
+      .vertical {
+        border: 2px solid #D0D0D0;
+        height: 200px;
+        left: 40px;
+        margin-top: -10px;
+        position: absolute;
+        width: 0;
       }
     }
 
-    .start, .finish {
-      background-color: #EDEDED;
-      display: inline;
-      padding: 5px;
-      text-transform: uppercase;
-    }
+    // Right-hand side collapsible text menu
+    .text {
+      padding-top: 15px;
 
-    .vertical {
-      border: 2px solid #D0D0D0;
-      height: 200px;
-      left: 40px;
-      margin-top: -10px;
-      position: absolute;
-      width: 0;
+      ul {
+        cursor: pointer;
+
+        li {
+          &:hover {
+            //background-color:
+          }
+        }
+      }
+
+      .start, .finish {
+        background-color: #EDEDED;
+        cursor: pointer;
+        display: inline;
+        padding: 5px;
+        text-transform: uppercase;
+
+
+      }
     }
   }
 }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -16,16 +16,16 @@
 
   // Integration Name Editor
   .name {
-    border-bottom: 2px solid #D0D0D0;
+    //border-bottom: 2px solid #D0D0D0;
     font-style: italic;
-    margin-top: -10px;
-    padding-bottom: 5px;
+    //margin-top: -10px;
+    //padding-bottom: 5px;
   }
 
   // Steps on left-hand side
   .steps {
     //margin-right: 65px;
-    padding-top: 20px;
+    //padding-top: 20px;
 
     // Left-hand side design with the cube and line
     .cube-line {
@@ -113,7 +113,7 @@
             padding: 5px 0;
 
             li {
-              padding: 5px 5px 5px 15px;
+              padding: 5px 5px 5px 17px;
 
               &.active {
                 background-color: #D6EEFA;
@@ -126,6 +126,11 @@
               }
             }
           }
+        }
+
+        .fa {
+          font-size: x-small;
+          padding-right: 5px;
         }
       }
     }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -21,20 +21,22 @@
 
   // Steps on left-hand side
   .steps {
+    //margin-right: 65px;
     padding-top: 20px;
-
-    ul {
-      padding-right: 35px;
-      -webkit-padding-start: 0;
-
-      li {
-        padding-left: 5px;
-      }
-    }
 
     // Left-hand side design with the cube and line
     .cube-line {
+      //padding-right: 0;
       text-align: center;
+
+      ul {
+        padding-right: 35px;
+        -webkit-padding-start: 0;
+
+        li {
+          padding-left: 5px;
+        }
+      }
 
       // Used for the containing <div> around any cubes to make e2e testing easier
       .cube {
@@ -72,12 +74,17 @@
 
     // Right-hand side collapsible text menu
     .text {
+      padding-right: 35px;
       padding-top: 15px;
 
       ul {
         cursor: pointer;
+        //padding-right: 35px;
+        -webkit-padding-start: 0;
 
         li {
+          padding-left: 5px;
+
           &:hover {
             //background-color:
           }
@@ -90,8 +97,6 @@
         display: inline;
         padding: 5px;
         text-transform: uppercase;
-
-
       }
     }
   }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.ts
@@ -22,14 +22,17 @@ export class FlowViewComponent implements OnInit, OnDestroy {
   urls: UrlSegment[];
   currentPosition: number;
   currentState: string;
-  isCollapsed: boolean = false;
   integrationName: string = '';
+  finishIsCollapsed: boolean = false;
+  startIsCollapsed: boolean = false;
 
   constructor(
     private currentFlow: CurrentFlow,
     private route: ActivatedRoute,
     private router: Router,
-  ) {}
+  ) {
+    this.i.name = 'Integration Name';
+  }
 
   getClass(state, position) {
     if (state === this.currentState && position === this.currentPosition) {
@@ -67,6 +70,8 @@ export class FlowViewComponent implements OnInit, OnDestroy {
     this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
       this.handleFlowEvent(event);
     });
+
+    log.debugc(() => 'Integration: ' + JSON.stringify(this.i));
   }
 
   ngOnDestroy() {

--- a/src/app/integrations/list/list.component.html
+++ b/src/app/integrations/list/list.component.html
@@ -1,5 +1,5 @@
 <ipaas-loading [loading]="loading">
-  <div class='list-group list-view-pf list-view-pf-view'>
+  <div class='list-group list-view-pf list-view-pf-view list integrations'>
     <div class='list-group-item integration' *ngFor='let integration of integrations'>
       <div class='list-view-pf-checkbox'>
         <input type='checkbox'>

--- a/src/app/integrations/list/list.component.scss
+++ b/src/app/integrations/list/list.component.scss
@@ -1,0 +1,10 @@
+.list.integrations {
+  .cards-pf .row-cards-pf:first-child {
+    padding-top: 0;
+  }
+
+  .card {
+    width: 25%;
+    max-height: 200px;
+  }
+}


### PR DESCRIPTION
Changes:
- Aesthetic changes for Create an Integration view to reflect designs more closely. (e.g. fix layout issue, sidebar)
- Fix lint error caused by previous PR merge w/ trailing whitespace.

Again, apologies for not squishing commits- it's crunch time. :)

### Create an Integration

<img width="1440" alt="screenshot 2017-02-16 08 52 21" src="https://cloud.githubusercontent.com/assets/3844502/23023914/cc530e0c-f425-11e6-9507-52a24a9e4d09.png">

In Progress (next PR, all minor tweaks):
- Center + icon in cube-line design on left-hand side
- Integration List improvements
- Connection Detail improvements

Low priority (may not happen for the demo):
- Automatically collapse the sidebar when in the Create Integration view, otherwise the layout is too wide and you can scroll to the right (for the demo we may have to manually collapse it).
- Look into issue where child components don't inherit CSS from parent components located in different modules.
- I might adjust the bottom bar of the Create Integration page to reflect designs to be gray and within the list (right now it kind of overlaps the sidebar), but since this will be moved to the top toolbar in the new designs it's likely not worth fixing at all, especially since it looks okay as is.
- Hover effect of steps in sidebar? Not sure if this was a thing, can ask UX.