### PR TITLE
Reflect integration state in the flow-view component

### DIFF
--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -61,7 +61,7 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
         // uh...
         break;
       case 'connection-configure':
-        // TODO hard-coding this to just go to the next connection
+        // TODO hard-coding this to just go to the previous connection
         this.router.navigate(['connection-select', this.position], { relativeTo: this.route });
         break;
       default:
@@ -101,6 +101,10 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy {
         break;
       case 'connection-configure':
         // TODO hard-coding this to just go to the next connection
+        this.currentFlow.events.emit({
+          kind: 'integration-connection-configured',
+          position: this.position,
+        });
         this.router.navigate(['connection-select', this.position + 1], { relativeTo: this.route });
         break;
       default:

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -2,49 +2,52 @@
   <div class="row name">
     <div class="col-md-12">
       <div class="form-group">
-        <input type="text" id="integrationName" class="form-control" placeholder="Enter integration name..." [ngModel]="integrationName" (ngModelChange)="integrationNameChanged($event)">
+        <input type="text" id="integrationName" class="form-control" placeholder="Enter integration name..." [ngModel]="integrationName"
+          (ngModelChange)="integrationNameChanged($event)">
       </div>
     </div>
   </div>
-  
+
   <!-- Steps -->
   <div class="row steps">
-    
+
     <!-- Cube Line -->
     <div class="col-md-3 cube-line">
       <!-- Cube Line: Cube -->
       <div class="cube">
-        <p class="round active">
-          <i class="fa fa-cube"></i>
+        <p [class]="'round ' + getActiveClass(undefined, 0)">
+          <i [class]="getIconClass(0)"></i>
         </p>
       </div>
-      
+
       <!-- Cube Line: Line -->
       <div class="vertical"></div>
-      
+
       <!-- Cube Line: Cube -->
       <div class="cube" style="margin-top: 200px;">
-        <p class="round inactive">
-          <i class="fa fa-cube"></i>
+        <p [class]="'round ' + getActiveClass(undefined, 1)">
+          <i [class]="getIconClass(1)"></i>
         </p>
       </div>
     </div>
-    
+
     <!-- Text Collapse Steps -->
     <div class="col-md-9 text">
       <div class="start">
         <h5>Start</h5>
         <ul>
-          <li (click)="startIsCollapsed = !startIsCollapsed">
-            <i class="fa fa-chevron-down"></i> Set up this connection
-            <ul (collapsed)="collapsed($event)"
-                (expanded)="expanded($event)"
-                [collapse]="startIsCollapsed">
-              <li>
-                <span [class]="getClass('connection-select', 0)">Choose a connection</span>
+          <!-- TODO this should eventually be an *ngFor driven by the currentFlow's steps -->
+          <li>
+            <span [class]="getTextClass(undefined, 0)">
+              <i *ngIf="!isCollapsed(0)" class="fa fa-chevron-down"></i>
+              <i *ngIf="isCollapsed(0)" class="fa fa-chevron-right"></i>
+              {{ getConnectionText(0) }}</span>
+            <ul [collapse]="isCollapsed(0)">
+              <li [class]="getActiveClass('connection-select', 0)">
+                <span [class]="getTextClass('connection-select', 0)">Choose a connection</span>
               </li>
-              <li>
-                <span [class]="getClass('connection-configure', 0)">Configure the connection</span>
+              <li [class]="getActiveClass('connection-configure', 0)">
+                <span [class]="getTextClass('connection-configure', 0)">Configure the connection</span>
               </li>
             </ul>
           </li>
@@ -53,16 +56,17 @@
       <div class="finish">
         <h5>Finish</h5>
         <ul>
-          <li (click)="finishIsCollapsed = !finishIsCollapsed">
-            <i class="fa fa-chevron-down"></i> Set up this connection
-            <ul (collapsed)="collapsed($event)"
-                (expanded)="expanded($event)"
-                [collapse]="finishIsCollapsed">
-              <li class="active">
-                <span [class]="getClass('connection-select', 1)">Choose a connection</span>
+          <li>
+            <span [class]="getTextClass(undefined, 1)">
+              <i *ngIf="!isCollapsed(0)" class="fa fa-chevron-down"></i>
+              <i *ngIf="isCollapsed(0)" class="fa fa-chevron-right"></i>
+              {{ getConnectionText(1) }}</span>
+            <ul [collapse]="isCollapsed(1)">
+              <li [class]="getActiveClass('connection-select', 1)">
+                <span [class]="getTextClass('connection-select', 1)">Choose a connection</span>
               </li>
-              <li class="inactive">
-                <span [class]="getClass('connection-configure', 1)">Configure the connection</span>
+              <li [class]="getActiveClass('connection-configure', 1)">
+                <span [class]="getTextClass('connection-configure', 1)">Configure the connection</span>
               </li>
             </ul>
           </li>

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -44,7 +44,7 @@
       // Used for the containing <div> around any cubes to make e2e testing easier
       .cube {
         // Overriding the actual cube icon's colors
-        .fa.fa-cube {
+        .fa {
           color: #D1D1D1;
           font-size: x-large;
         }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.ts
@@ -23,8 +23,6 @@ export class FlowViewComponent implements OnInit, OnDestroy {
   currentPosition: number;
   currentState: string;
   integrationName: string = '';
-  finishIsCollapsed: boolean = false;
-  startIsCollapsed: boolean = false;
 
   constructor(
     private currentFlow: CurrentFlow,
@@ -34,8 +32,25 @@ export class FlowViewComponent implements OnInit, OnDestroy {
     this.i.name = 'Integration Name';
   }
 
-  getClass(state, position) {
-    if (state === this.currentState && position === this.currentPosition) {
+  getIconClass(position) {
+    const step = this.currentFlow.getStep(position);
+    if (!step || !step['icon']) {
+      return 'fa fa-cube';
+    } else {
+      return 'fa ' + step['icon'];
+    }
+  }
+
+  getActiveClass(state, position) {
+    if ((!state || state === this.currentState) && position === this.currentPosition) {
+      return 'active';
+    } else {
+      return 'inactive';
+    }
+  }
+
+  getTextClass(state, position) {
+    if ((!state || state === this.currentState) && position === this.currentPosition) {
       return 'bold';
     } else {
       return '';
@@ -66,6 +81,18 @@ export class FlowViewComponent implements OnInit, OnDestroy {
     }
   }
 
+  getConnectionText(position: number) {
+    const step = this.currentFlow.getStep(position);
+    if (step) {
+      return 'Set up ' + step['name'];
+    }
+    return 'Set up this connection';
+  }
+
+  isCollapsed(position: number) {
+    return this.currentFlow.getStep(position) !== undefined;
+  }
+
   ngOnInit() {
     this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
       this.handleFlowEvent(event);
@@ -76,14 +103,6 @@ export class FlowViewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.flowSubscription.unsubscribe();
-  }
-
-  collapsed(event: any): void {
-    log.debugc(() => 'Event' + event);
-  }
-
-  expanded(event: any): void {
-    log.debugc(() => 'Event' + event);
   }
 
 }

--- a/src/app/integrations/create-page/select-connection/select-connection.component.ts
+++ b/src/app/integrations/create-page/select-connection/select-connection.component.ts
@@ -72,6 +72,17 @@ export class IntegrationsSelectConnectionComponent implements OnInit, OnDestroy 
         });
       })
       .subscribe();
+    this.connections.map((connections: Connections) => {
+      const config = this.currentFlow.getStep(this.position);
+      if (config) {
+        const id = config.id;
+        for (const connection of connections) {
+          if (connection.id === id) {
+            log.debugc(() => 'Found connection: ' + connection.name, category);
+          }
+        }
+      }
+    });
     this.store.loadAll();
   }
 

--- a/src/app/store/entity/entity.store.ts
+++ b/src/app/store/entity/entity.store.ts
@@ -87,6 +87,7 @@ export abstract class AbstractStore<T extends BaseEntity, L extends Array<T>,
       },
       (error) => {
         log.errorc(() => 'Error creating ' + this.kind + ' (' + JSON.stringify(entity, null, 2) + ')' + ': ' + error, category);
+        created.error(error);
       });
     return created.share();
   }


### PR DESCRIPTION
This makes the sidebar reflect the state of the integration as the user selects connections, the expanding items are closed and the icon available on the connection replaces the cube.

![fireshot capture 1 - red hat ipaas_ - http___localhost_4200_integrations_](https://cloud.githubusercontent.com/assets/351660/23027486/5cb2ea7e-f432-11e6-85fd-89909d12f19a.png)
