### PR TITLE
Fix store service error exception, display connection fields on conne…

### DIFF
--- a/src/app/connections/view/view.component.html
+++ b/src/app/connections/view/view.component.html
@@ -17,21 +17,22 @@
     <div class="card-pf">
       <h2 class="card-pf-title">Connection Fields</h2>
       <div class="card-pf-body">
-        <form class="form-horizontal">
-          <!-- replacing id with data-id to pass build errors -->
-          <div class="form-group required">
-            <label class="col-sm-4 control-label">Connection Name</label>
-            <div class="col-sm-8">
-              <input type="text" name="nameInput" data-id="nameInput" [value]="connection.name" [disabled]="true" class="form-control">
-            </div>
+        <div *ngIf="mode === 'view'">
+          <div *ngFor="let field of getFormFields(connection)">
+            <dl class="dl-horizontal">
+              <dt>
+                {{ field.name }}
+              </dt>
+              <dd>
+                {{ field.value || "&lt;not set&gt;" }}
+              </dd>
+            </dl>
+
           </div>
-          <div class="form-group">
-            <label class="col-sm-4 control-label">Description</label>
-            <div class="col-sm-8">
-              <textarea data-id="descriptionInput" name="descriptionInput" class="form-control" [disabled]="true" [value]="connection.description" rows="2"></textarea>
-            </div>
-          </div>
-        </form>
+        </div>
+        <div *ngIf="mode === 'edit'">
+          <p>edit></p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/connections/view/view.component.ts
+++ b/src/app/connections/view/view.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { Connection } from '../../store/connection/connection.model';
 
@@ -7,8 +7,38 @@ import { Connection } from '../../store/connection/connection.model';
   templateUrl: './view.component.html',
   styleUrls: ['./view.component.scss'],
 })
-export class ConnectionViewComponent {
+export class ConnectionViewComponent implements OnInit {
 
   @Input() connection: Connection;
+  mode: string = 'view';
+
+  constructor() {
+
+  }
+
+  getFormFields(connection: Connection) {
+    const answer = [];
+    let formFields = undefined;
+    try {
+      formFields = JSON.parse(connection.configuredProperties);
+    } catch (err) {
+      // silently fail
+    }
+    if (formFields) {
+      for (const key in formFields) {
+        if (!formFields.hasOwnProperty(key)) {
+          continue;
+        }
+        const field = formFields[key];
+        field.name = key;
+        answer.push(field);
+      }
+    }
+    return answer;
+  }
+
+  ngOnInit() {
+    this.connection = <Connection>{};
+  }
 
 }

--- a/src/app/integrations/create-page/create-page.component.ts
+++ b/src/app/integrations/create-page/create-page.component.ts
@@ -88,7 +88,10 @@ export class IntegrationsCreatePage implements OnInit, OnDestroy, AfterViewInit 
     const router = this.router;
     this.currentFlow.events.emit({
       kind: 'integration-save',
-      action: () => {
+      action: (i: Integration) => {
+        router.navigate(['/integrations']);
+      },
+      error: (error) => {
         router.navigate(['/integrations']);
       },
     });

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -90,15 +90,18 @@ export class CurrentFlow {
           });
         }
         integration.steps = newSteps;
-        this.store.create(integration).map((i: Integration) => {
+        this.store.create(integration).toPromise().then((i: Integration) => {
           log.debugc(() => 'Saved integration: ' + JSON.stringify(i, undefined, 2), category);
           const action = event['action'];
           if (action && typeof action === 'function') {
             action(i);
           }
-        }).catch((reason: any, caught: Observable<void>): Observable<{}> => {
+        }).catch((reason: any) => {
           log.debugc(() => 'Error saving integration: ' + JSON.stringify(reason, undefined, 2), category);
-          return undefined;
+          const errorAction = event['error'];
+          if (errorAction && typeof errorAction === 'function') {
+            errorAction(reason);
+          }
         });
       break;
     }

--- a/src/app/store/entity/entity.store.ts
+++ b/src/app/store/entity/entity.store.ts
@@ -40,7 +40,7 @@ export abstract class AbstractStore<T extends BaseEntity, L extends Array<T>,
         this._loading.next(false);
       },
       (error) => {
-        log.errorc(() => 'Error retrieving ' + plural(this.kind) + ': ' + error, category);
+        log.debugc(() => 'Error retrieving ' + plural(this.kind) + ': ' + error, category);
         this._loading.next(false);
       });
   }
@@ -74,7 +74,7 @@ export abstract class AbstractStore<T extends BaseEntity, L extends Array<T>,
         this._loading.next(false);
       },
       (error) => {
-        log.errorc(() => 'Error retrieving ' + this.kind + ': ' + error, category);
+        log.debugc(() => 'Error retrieving ' + this.kind + ': ' + error, category);
         this._loading.next(false);
       });
   }
@@ -86,7 +86,7 @@ export abstract class AbstractStore<T extends BaseEntity, L extends Array<T>,
         created.next(this.plain(e));
       },
       (error) => {
-        log.errorc(() => 'Error creating ' + this.kind + ' (' + JSON.stringify(entity, null, 2) + ')' + ': ' + error, category);
+        log.debugc(() => 'Error creating ' + this.kind + ' (' + JSON.stringify(entity, null, 2) + ')' + ': ' + error, category);
         created.error(error);
       });
     return created.share();
@@ -99,7 +99,7 @@ export abstract class AbstractStore<T extends BaseEntity, L extends Array<T>,
         updated.next(this.plain(e));
       },
       (error) => {
-        log.errorc(() => 'Error updating ' + this.kind + ' (' + JSON.stringify(entity, null, 2) + ')' + ': ' + error, category);
+        log.debugc(() => 'Error updating ' + this.kind + ' (' + JSON.stringify(entity, null, 2) + ')' + ': ' + error, category);
       });
     return updated.share();
   }


### PR DESCRIPTION
…ction view page, fix up page flow from integration editor

This fixes the connection view page to show the available fields and their settings, also the store services were erroring out when getting HTTP error returns, this sorts that so views can handle errors.

Also this ensures the create integration flow transitions back to the integration list when you click create, note we don't have toaster notifications in place yet, so we don't yet have a decent way to notify the user if the integration was created or if there was an error.