### PR TITLE
[WIP] Use a proper ngFor in the flow view, use flex parent to lay out child elements

### DIFF
--- a/src/app/integrations/create-page/create-page.component.spec.ts
+++ b/src/app/integrations/create-page/create-page.component.spec.ts
@@ -9,6 +9,7 @@ import { RestangularModule } from 'ng2-restangular';
 
 import { IPaaSCommonModule } from '../../common/common.module';
 import { FlowViewComponent } from './flow-view/flow-view.component';
+import { FlowViewStepComponent } from './flow-view/flow-view-step.component';
 import { ConnectionsListComponent } from '../../connections/list/list.component';
 import { ConnectionsListToolbarComponent } from '../../connections/list-toolbar/list-toolbar.component';
 import { StoreModule } from '../../store/store.module';
@@ -38,6 +39,7 @@ describe('IntegrationsCreateComponent', () => {
         ConnectionsListComponent,
         ConnectionsListToolbarComponent,
         FlowViewComponent,
+        FlowViewStepComponent,
       ],
       providers: [
         MockBackend,

--- a/src/app/integrations/create-page/current-flow.service.spec.ts
+++ b/src/app/integrations/create-page/current-flow.service.spec.ts
@@ -1,0 +1,144 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+import { RestangularModule } from 'ng2-restangular';
+
+import { CurrentFlow, FlowEvent } from './current-flow.service';
+import { IntegrationStore } from '../../store/integration/integration.store';
+import { IntegrationService } from '../../store/integration/integration.service';
+import { Connection, Integration, Step } from '../../model';
+
+describe('ConfigService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RestangularModule.forRoot(),
+      ],
+      providers: [
+        CurrentFlow,
+        IntegrationStore,
+        IntegrationService,
+        MockBackend,
+        { provide: RequestOptions, useClass: BaseRequestOptions },
+        {
+          provide: Http, useFactory: (backend, options) => {
+            return new Http(backend, options);
+          }, deps: [MockBackend, RequestOptions],
+        }],
+    });
+  });
+
+  function getDummyIntegration(): Integration {
+    return <Integration>{
+      connections: [
+        {
+          id: '1',
+          kind: 'connection',
+        },
+        {
+          id: '2',
+          kind: 'connection',
+        }],
+      steps: [
+        {
+          id: '1',
+          kind: 'endpoint',
+        },
+        {
+          id: '6',
+          kind: 'whatever',
+        },
+        {
+          id: '9',
+          kind: 'sumthin\' else',
+        },
+        {
+          id: '2',
+          kind: 'endpoint',
+        },
+      ],
+    };
+  }
+
+  it('should return the first step in the flow', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = getDummyIntegration();
+    const step: any = service.getStartConnection();
+    expect(step['id']).toEqual('1');
+    expect(step['kind']).toEqual('connection');
+  }));
+
+  it('should return the last step in the flow', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = getDummyIntegration();
+    const step: any = service.getEndConnection();
+    expect(step['id']).toEqual('2');
+    expect(step['kind']).toEqual('connection');
+  }));
+
+  it('should return the middle steps in the flow', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = getDummyIntegration();
+    const steps: any[] = service.getMiddleSteps();
+    expect(steps.length).toEqual(2);
+    expect(steps[0]['id']).toEqual('6');
+    expect(steps[0]['kind']).toEqual('whatever');
+  }));
+
+  it('Should return an undefined start and end connection with an empty integration', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = <Integration> {};
+    expect(service.getStartConnection()).toBeUndefined();
+    expect(service.getEndConnection()).toBeUndefined();
+    expect(service.getFirstPosition()).toEqual(0);
+    expect(service.getLastPosition()).toEqual(1);
+  }));
+
+  it('Should give me an undefined end connection when I add a start connection', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = <Integration> {};
+    service.connections.push(<Connection> {
+      id: '1',
+      kind: 'connection',
+      name: 'foo',
+    });
+    service.steps.push(<Step>{
+      id: '1',
+      kind: 'endpoint',
+    });
+    const start = service.getStartConnection();
+    expect(start.id).toBe('1');
+    expect(start.name).toBe('foo');
+    const end = service.getEndConnection();
+    expect(end).toBeUndefined();
+    expect(service.getFirstPosition()).toEqual(0);
+    expect(service.getLastPosition()).toEqual(1);
+  }));
+
+  it('Should give me the right end connection when I add start and end connections', inject([CurrentFlow], (service: CurrentFlow) => {
+    service.integration = <Integration>{};
+    // start connection;
+    service.connections.push(<Connection>{
+      id: '1',
+      kind: 'connection',
+      name: 'foo',
+    });
+    service.steps.push(<Step>{
+      id: '1',
+      kind: 'endpoint',
+    });
+    // start connection;
+    service.connections.push(<Connection>{
+      id: '2',
+      kind: 'connection',
+      name: 'bar',
+    });
+    service.steps.push(<Step>{
+      id: '2',
+      kind: 'endpoint',
+    });
+    const start = service.getStartConnection();
+    expect(start.id).toBe('1');
+    expect(start.name).toBe('foo');
+    const end = service.getEndConnection();
+    expect(end.id).toBe('2');
+    expect(end.name).toBe('bar');
+    expect(service.getFirstPosition()).toEqual(0);
+    expect(service.getLastPosition()).toEqual(1);
+  }));
+});

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -38,6 +38,13 @@ export class CurrentFlow {
     }
   }
 
+  getConnection(id: string): Connection {
+    const connections = this._integration.connections;
+    return connections.find((connection) => {
+      return connection.id === id;
+    });
+  }
+
   getStep(position: number): Step | Connection {
     if (!this._integration) {
       return undefined;
@@ -47,8 +54,9 @@ export class CurrentFlow {
     if (!step) {
       return undefined;
     }
-    if (step.kind === 'connection') {
-      return this._integration.connections[position];
+    // TODO the backend isn't saving the 'kind' field. fudge it
+    if (step.kind === 'endpoint' || step.kind === 'connection' || !step.kind) {
+      return this.getConnection(step.id);
     } else {
       return step;
     }
@@ -84,7 +92,7 @@ export class CurrentFlow {
       this._integration.steps[position] = <Step> {
         configuredProperties: connection['configuredProperties'],
         id: connection['id'],
-        kind: 'connection',
+        kind: 'endpoint',
       };
       log.debugc(() => 'Set connection ' + connection.name + ' at position: ' + position, category);
       break;

--- a/src/app/integrations/create-page/current-flow.service.ts
+++ b/src/app/integrations/create-page/current-flow.service.ts
@@ -29,28 +29,63 @@ export class CurrentFlow {
 
   isValid() {
     // TODO more validations on the integration
-    return (this._integration.name && this._integration.name.length);
-  }
-
-  private createSteps() {
-    if (!this._integration.steps) {
-      this._integration.steps = [];
-    }
+    return (this.integration.name && this.integration.name.length);
   }
 
   getConnection(id: string): Connection {
-    const connections = this._integration.connections;
-    return connections.find((connection) => {
+    if (!this.integration) {
+      return undefined;
+    }
+    return this.connections.find((connection) => {
       return connection.id === id;
     });
   }
 
-  getStep(position: number): Step | Connection {
-    if (!this._integration) {
+  getStartConnection(): Connection {
+    return <Connection> this.getStep(this.getFirstPosition());
+  }
+
+  getEndConnection(): Connection {
+    const lastPosition = this.getLastPosition();
+    if (lastPosition < 1) {
       return undefined;
     }
-    this.createSteps();
-    const step = this._integration.steps[position];
+    return <Connection> this.getStep(this.getLastPosition());
+  }
+
+  getMiddleSteps(): Array<any> {
+    const answer: Array<any> = [];
+    if (this.getLastPosition() < 2) {
+      return answer;
+    }
+    if (!this.steps) {
+      return answer;
+    }
+    const middle = this.steps.slice(1, -1);
+    for (const s of middle) {
+      answer.push(this.stepToConnection(<Step> s));
+    }
+    return answer;
+  }
+
+  getFirstPosition(): number {
+    if (!this.integration) {
+      return undefined;
+    }
+    return 0;
+  }
+
+  getLastPosition(): number {
+    if (!this.integration) {
+      return undefined;
+    }
+    if (this.steps.length <= 1) {
+      return 1;
+    }
+    return this.steps.length - 1;
+  }
+
+  stepToConnection(step: Step) {
     if (!step) {
       return undefined;
     }
@@ -62,34 +97,38 @@ export class CurrentFlow {
     }
   }
 
+  getStep(position: number): Step | Connection {
+    if (!this.integration) {
+      return undefined;
+    }
+    return this.stepToConnection(<Step> this.steps[position]);
+  }
+
   isEmpty(): boolean {
-    if (!this._integration) {
+    if (!this.integration) {
       return true;
     }
-    this.createSteps();
-    return this._integration.steps.length === 0;
+    return this.steps.length === 0;
   }
 
   atEnd(position: number): boolean {
-    if (!this._integration) {
+    if (!this.integration) {
       return true;
     }
-    this.createSteps();
-    return position >= this._integration.steps.length;
+    return position >= this.steps.length;
   }
 
   handleEvent(event: FlowEvent): void {
     log.debugc(() => 'event: ' + JSON.stringify(event, undefined, 2), category);
     switch (event.kind) {
       case 'integration-set-connection':
-      this.createSteps();
       const position = +event['position'];
       let connection = event['connection'];
       if (connection.plain && typeof connection.plain === 'function') {
         connection = connection.plain();
       }
-      this._integration.connections[position] = connection;
-      this._integration.steps[position] = <Step> {
+      this.connections[position] = connection;
+      this.steps[position] = <Step> {
         configuredProperties: connection['configuredProperties'],
         id: connection['id'],
         kind: 'endpoint',
@@ -100,9 +139,9 @@ export class CurrentFlow {
       this._integration.name = event['name'];
       break;
       case 'integration-save':
-        log.debugc(() => 'Saving integration: ' + this._integration);
+        log.debugc(() => 'Saving integration: ' + this.integration);
         // poor man's clone in case we need to munge the data
-        const integration = JSON.parse(JSON.stringify(this._integration));
+        const integration = JSON.parse(JSON.stringify(this.integration));
         // TODO munging connection objects for now
         /*
         const steps = integration.steps;
@@ -132,17 +171,42 @@ export class CurrentFlow {
   }
 
   get integration(): Integration {
+    if (!this._integration) {
+      return undefined;
+    }
     return this._integration;
   }
 
+  get connections(): Array<Connection> {
+    if (!this._integration) {
+      return undefined;
+    } else {
+      if (!this._integration.connections) {
+        this._integration.connections = [];
+      }
+      return this._integration.connections;
+    }
+  }
+
+  get steps(): Array<Step | Connection> {
+    if (!this._integration) {
+      return undefined;
+    } else {
+      if (!this._integration.steps) {
+        this._integration.steps = [];
+      }
+      return this._integration.steps;
+    }
+  }
+
   set integration(i: Integration) {
-    this._integration = i;
+    this._integration = <Integration> i;
     log.debugc(() => 'Integration reset for current flow', category);
     this.events.emit({
       kind: 'integration-updated',
-      integration: this._integration,
+      integration: this.integration,
     });
-    if (!i.steps || !i.steps.length) {
+    if (!this.steps || !this.steps.length) {
       log.debugc(() => 'Integration has no steps, assuming it\'s new', category);
       this.events.emit({
         kind: 'integration-no-connections',

--- a/src/app/integrations/create-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view-step.component.html
@@ -1,0 +1,24 @@
+<div class="col-md-3 progress-line">
+  <!-- Icon Line: Plus -->
+  <div class="icon">
+    <p [class]="'round ' + getActiveClass(undefined, position)">
+      <i [class]="getIconClass(position)"></i>
+    </p>
+  </div>
+</div>
+<div class="col-md-9 text">
+  <span [class]="getTextClass(undefined, position)">
+                      <i *ngIf="!isCollapsed(position)"
+                        class="fa fa-chevron-down"></i>                     
+                      <i *ngIf="isCollapsed(position)"
+                        class="fa fa-chevron-right"></i>
+                      {{ getConnectionText(position) }}</span>
+  <ul [collapse]="isCollapsed(position)">
+    <li [class]="getActiveClass('connection-select', position)">
+      <span [class]="getTextClass('connection-select', position)">Choose a connection</span>
+    </li>
+    <li [class]="getActiveClass('connection-configure', position)">
+      <span [class]="getTextClass('connection-configure', position)">Configure the connection</span>
+    </li>
+  </ul>
+</div>

--- a/src/app/integrations/create-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view-step.component.scss
@@ -1,0 +1,102 @@
+ul {
+  list-style-type: none;
+  -webkit-margin-before: 0;
+
+  li {
+    list-style-type: none;
+  }
+}
+
+// Left-hand side design with the icon and line
+.progress-line {
+  //padding-right: 0;
+  text-align: center;
+
+  ul {
+    padding-right: 35px;
+    -webkit-padding-start: 0;
+
+    li {
+      padding-left: 5px;
+    }
+  }
+
+  // Line that connects cubes
+  .vertical {
+    border: 2px solid #D0D0D0;
+    height: 200px;
+    left: 40px;
+    margin-top: -10px;
+    position: absolute;
+    width: 0;
+  }
+  .icon {
+    padding-top: 0px;
+    // Overriding the actual cube icon's colors
+    .fa {
+      color: #D1D1D1;
+      font-size: x-large;
+    }
+
+    .round {
+      -moz-border-radius: 100px;
+      border-radius: 100px;
+      padding: 11px;
+      width: 55px;
+      height: 55px;
+
+      &.active {
+        border: 3px solid #1487CB;
+      }
+
+      &.inactive {
+        border: 3px solid #D0D0D0;
+      }
+    }
+  }
+}
+
+.text {
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 15px;
+  ul {
+    cursor: pointer;
+    padding-right: 35px;
+    -webkit-padding-start: 0;
+  }
+  .start, .finish {
+    h5 {
+      background-color: #EDEDED;
+      cursor: pointer;
+      display: inline;
+      padding: 5px;
+      text-transform: uppercase;
+    }
+    ul {
+      min-width: 160px;
+      padding: 10px 0;
+      // Sub-Menu Items
+      &.collapse {
+        margin-top: 5px;
+        padding: 5px 0;
+
+        li {
+          padding: 5px 5px 5px 17px;
+          &.active {
+            background-color: #D6EEFA;
+            border-bottom: 1px solid #B8DFF3;
+            border-top: 1px solid #B8DFF3;
+          }
+          &.inactive {
+            color: #D1D1D1;
+          }
+        }
+      }
+    }
+    .fa {
+      font-size: x-small;
+      padding-right: 5px;
+    }
+  }
+}

--- a/src/app/integrations/create-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view-step.component.ts
@@ -1,0 +1,111 @@
+import { Component, Input, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+
+import { log, getCategory } from '../../../logging';
+import { CurrentFlow, FlowEvent } from '../current-flow.service';
+import { Integration, Step } from '../../../model';
+
+const category = getCategory('IntegrationsCreatePage');
+
+@Component({
+  selector: 'ipaas-integrations-flow-view-step',
+  templateUrl: './flow-view-step.component.html',
+  styleUrls: ['./flow-view-step.component.scss'],
+})
+export class FlowViewStepComponent implements OnInit, OnDestroy {
+
+  // the step object in the current flow
+  @Input()
+  step: Step;
+
+  // the position in the integration flow
+  @Input()
+  position: number;
+
+  // the current step in the flow the user is working with
+  @Input()
+  currentPosition: number;
+
+  // the current state/page of the current step
+  @Input()
+  currentState: string;
+
+  constructor(
+    private currentFlow: CurrentFlow,
+    private detector: ChangeDetectorRef,
+  ) {
+
+  }
+
+  getState() {
+    return {
+      step: this.step,
+      position: this.position,
+      currentPosition: this.currentPosition,
+      currentState: this.currentState,
+      firstPosition: this.currentFlow.getFirstPosition(),
+      lastPosition: this.currentFlow.getLastPosition(),
+    };
+  }
+
+  getIconClass(position) {
+    if (!this.step || !this.step['icon']) {
+      return 'fa fa-plus';
+    } else {
+      return 'fa ' + this.step['icon'];
+    }
+  }
+
+  getActiveClass(state, position) {
+    if (this.position === -1) {
+      position = this.currentFlow.getLastPosition();
+    }
+    if ((!state || state === this.currentState) && position === this.currentPosition) {
+      return 'active';
+    } else {
+      return 'inactive';
+    }
+  }
+
+  getTextClass(state, position) {
+    if (this.position === -1) {
+      position = this.currentFlow.getLastPosition();
+    }
+    if ((!state || state === this.currentState) && position === this.currentPosition) {
+      return 'bold';
+    } else {
+      return '';
+    }
+  }
+
+  getConnectionText(position: number) {
+    if (this.step) {
+      return this.step['name'];
+    }
+    if (position === this.currentFlow.getFirstPosition()) {
+      return 'Start';
+    }
+    if (position === this.currentFlow.getLastPosition()) {
+      return 'Finish';
+    }
+    return 'Set up this connection';
+  }
+
+  isCollapsed(position: number) {
+    return this.step !== undefined;
+  }
+
+  ngOnInit() {
+
+  }
+
+  ngOnDestroy() {
+
+  }
+
+
+
+
+}

--- a/src/app/integrations/create-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -14,7 +14,7 @@ const category = getCategory('IntegrationsCreatePage');
   templateUrl: './flow-view-step.component.html',
   styleUrls: ['./flow-view-step.component.scss'],
 })
-export class FlowViewStepComponent implements OnInit, OnDestroy {
+export class FlowViewStepComponent {
 
   // the step object in the current flow
   @Input()
@@ -34,7 +34,6 @@ export class FlowViewStepComponent implements OnInit, OnDestroy {
 
   constructor(
     private currentFlow: CurrentFlow,
-    private detector: ChangeDetectorRef,
   ) {
 
   }
@@ -84,10 +83,10 @@ export class FlowViewStepComponent implements OnInit, OnDestroy {
     if (this.step) {
       return this.step['name'];
     }
-    if (position === this.currentFlow.getFirstPosition()) {
+    if (position === 0) {
       return 'Start';
     }
-    if (position === this.currentFlow.getLastPosition()) {
+    if (position === -1) {
       return 'Finish';
     }
     return 'Set up this connection';
@@ -96,16 +95,4 @@ export class FlowViewStepComponent implements OnInit, OnDestroy {
   isCollapsed(position: number) {
     return this.step !== undefined;
   }
-
-  ngOnInit() {
-
-  }
-
-  ngOnDestroy() {
-
-  }
-
-
-
-
 }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -11,23 +11,53 @@
       </div>
     </div>
   </div>
+
+  <div class="flow-view-container">
+    <div *ngFor="let step of getSteps(); let position = index;" [class]="'row steps ' + getRowClass(position)">
+      <div class="col-md-3 progress-line">
+        <!-- Cube Line: Cube -->
+        <div class="icon">
+          <p [class]="'round ' + getActiveClass(undefined, position)">
+            <i [class]="getIconClass(position)"></i>
+          </p>
+        </div>
+      </div>
+      <div class="col-md-9 text">
+        <span [class]="getTextClass(undefined, position)">
+                      <i *ngIf="!isCollapsed(position)"
+                        class="fa fa-chevron-down"></i>
+                      <i *ngIf="isCollapsed(position)"
+                        class="fa fa-chevron-right"></i>
+                      {{ getConnectionText(position) }}</span>
+        <ul [collapse]="isCollapsed(position)">
+          <li [class]="getActiveClass('connection-select', position)">
+            <span [class]="getTextClass('connection-select', position)">Choose a connection</span>
+          </li>
+          <li [class]="getActiveClass('connection-configure', position)">
+            <span [class]="getTextClass('connection-configure', position)">Configure the connection</span>
+          </li>      
+        </ul>
+      </div>
+    </div>
+  </div>
   
-  <!-- Steps -->
-  <div class="row steps">
+  
+  <!-- Steps -/->
+  <div class="row steps" style="display: none;">
     
-    <!-- Cube Line -->
+    <!-- Cube Line -/->
     <div class="col-md-3 progress-line">
-      <!-- Cube Line: Cube -->
+      <!-- Cube Line: Cube -/->
       <div class="icon">
         <p [class]="'round ' + getActiveClass(undefined, 0)">
           <i [class]="getIconClass(0)"></i>
         </p>
       </div>
       
-      <!-- Progress Line: Line -->
+      <!-- Progress Line: Line -/->
       <div class="vertical"></div>
       
-      <!-- Progress Line: Icon -->
+      <!-- Progress Line: Icon -/->
       <div class="icon"
            style="margin-top: 200px;">
         <p [class]="'round ' + getActiveClass(undefined, 1)">
@@ -36,12 +66,12 @@
       </div>
     </div>
     
-    <!-- Text Collapse Steps -->
+    <!-- Text Collapse Steps -/->
     <div class="col-md-9 text">
       <div class="start">
         <h5>Start</h5>
         <ul>
-          <!-- TODO this should eventually be an *ngFor driven by the currentFlow's steps -->
+          <!-- TODO this should eventually be an *ngFor driven by the currentFlow's steps -/->
           <li>
             <span [class]="getTextClass(undefined, 0)">
               <i *ngIf="!isCollapsed(0)"
@@ -81,13 +111,6 @@
           </li>
         </ul>
       </div>
-    </div>
-  </div>
-  <!-- debug -->
-  <!--
-  <div class="row">
-    <div class="col-md-12">
-      <pre>{{integration | json}}</pre>
     </div>
   </div>
   -->

--- a/src/app/integrations/create-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.html
@@ -1,117 +1,41 @@
 <div class="flow-view">
-  <div class="row name">
-    <div class="col-md-12">
-      <div class="form-group">
-        <input type="text"
-               id="integrationName"
-               class="form-control"
-               placeholder="Enter integration name..."
-               [ngModel]="integrationName"
-               (ngModelChange)="integrationNameChanged($event)">
-      </div>
-    </div>
-  </div>
-
-  <div class="flow-view-container">
-    <div *ngFor="let step of getSteps(); let position = index;" [class]="'row steps ' + getRowClass(position)">
-      <div class="col-md-3 progress-line">
-        <!-- Cube Line: Cube -->
-        <div class="icon">
-          <p [class]="'round ' + getActiveClass(undefined, position)">
-            <i [class]="getIconClass(position)"></i>
-          </p>
+  <ipaas-loading [loading]="loaded()">
+    <div class="row name">
+      <div class="col-md-12">
+        <div class="form-group">
+          <input type="text"
+                id="integrationName"
+                class="form-control"
+                placeholder="Enter integration name..."
+                [ngModel]="integrationName"
+                (ngModelChange)="integrationNameChanged($event)">
         </div>
       </div>
-      <div class="col-md-9 text">
-        <span [class]="getTextClass(undefined, position)">
-                      <i *ngIf="!isCollapsed(position)"
-                        class="fa fa-chevron-down"></i>
-                      <i *ngIf="isCollapsed(position)"
-                        class="fa fa-chevron-right"></i>
-                      {{ getConnectionText(position) }}</span>
-        <ul [collapse]="isCollapsed(position)">
-          <li [class]="getActiveClass('connection-select', position)">
-            <span [class]="getTextClass('connection-select', position)">Choose a connection</span>
-          </li>
-          <li [class]="getActiveClass('connection-configure', position)">
-            <span [class]="getTextClass('connection-configure', position)">Configure the connection</span>
-          </li>      
-        </ul>
+    </div>
+
+    <div class="flow-view-container" *ngIf="i && i.steps">
+      <div class="row steps start">
+        <ipaas-integrations-flow-view-step   
+          [step]="startConnection()" 
+          [position]="0" 
+          [currentPosition]="currentPosition" 
+          [currentState]="currentState"></ipaas-integrations-flow-view-step >
+      </div>
+      <div class="row steps" *ngFor="let step of getMiddleSteps(); let position = index;">
+        <ipaas-integrations-flow-view-step   
+          [step]="step" 
+          [position]="position" 
+          [currentPosition]="currentPosition" 
+          [currentState]="currentState"></ipaas-integrations-flow-view-step >
+      </div>
+      <div class="row steps finish">
+        <ipaas-integrations-flow-view-step   
+          [step]="endConnection()" 
+          [position]="-1" 
+          [currentPosition]="currentPosition" 
+          [currentState]="currentState"></ipaas-integrations-flow-view-step >
       </div>
     </div>
-  </div>
+  </ipaas-loading>
   
-  
-  <!-- Steps -/->
-  <div class="row steps" style="display: none;">
-    
-    <!-- Cube Line -/->
-    <div class="col-md-3 progress-line">
-      <!-- Cube Line: Cube -/->
-      <div class="icon">
-        <p [class]="'round ' + getActiveClass(undefined, 0)">
-          <i [class]="getIconClass(0)"></i>
-        </p>
-      </div>
-      
-      <!-- Progress Line: Line -/->
-      <div class="vertical"></div>
-      
-      <!-- Progress Line: Icon -/->
-      <div class="icon"
-           style="margin-top: 200px;">
-        <p [class]="'round ' + getActiveClass(undefined, 1)">
-          <i [class]="getIconClass(1)"></i>
-        </p>
-      </div>
-    </div>
-    
-    <!-- Text Collapse Steps -/->
-    <div class="col-md-9 text">
-      <div class="start">
-        <h5>Start</h5>
-        <ul>
-          <!-- TODO this should eventually be an *ngFor driven by the currentFlow's steps -/->
-          <li>
-            <span [class]="getTextClass(undefined, 0)">
-              <i *ngIf="!isCollapsed(0)"
-                 class="fa fa-chevron-down"></i>
-              <i *ngIf="isCollapsed(0)"
-                 class="fa fa-chevron-right"></i>
-              {{ getConnectionText(0) }}</span>
-            <ul [collapse]="isCollapsed(0)">
-              <li [class]="getActiveClass('connection-select', 0)">
-                <span [class]="getTextClass('connection-select', 0)">Choose a connection</span>
-              </li>
-              <li [class]="getActiveClass('connection-configure', 0)">
-                <span [class]="getTextClass('connection-configure', 0)">Configure the connection</span>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-      <div class="finish">
-        <h5>Finish</h5>
-        <ul>
-          <li>
-            <span [class]="getTextClass(undefined, 1)">
-              <i *ngIf="!isCollapsed(0)"
-                 class="fa fa-chevron-down"></i>
-              <i *ngIf="isCollapsed(0)"
-                 class="fa fa-chevron-right"></i>
-              {{ getConnectionText(1) }}</span>
-            <ul [collapse]="isCollapsed(1)">
-              <li [class]="getActiveClass('connection-select', 1)">
-                <span [class]="getTextClass('connection-select', 1)">Choose a connection</span>
-              </li>
-              <li [class]="getActiveClass('connection-configure', 1)">
-                <span [class]="getTextClass('connection-configure', 1)">Configure the connection</span>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  -->
 </div>

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -1,6 +1,13 @@
 .flow-view {
   width: 300px;
 
+  .flow-view-container {
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
   ul {
     list-style-type: none;
     -webkit-margin-before: 0;
@@ -43,6 +50,7 @@
 
       // Used for the containing <div> around any cubes to make e2e testing easier
       .icon {
+        padding-top: 0px;
         // Overriding the actual cube icon's colors
         .fa {
           color: #D1D1D1;
@@ -52,7 +60,9 @@
         .round {
           -moz-border-radius: 100px;
           border-radius: 100px;
-          padding: 7px;
+          padding: 11px;
+          width: 55px;
+          height: 55px;
 
           &.active {
             border: 3px solid #1487CB;
@@ -77,6 +87,7 @@
 
     // Right-hand side collapsible text menu
     .text {
+      padding-left: 0;
       padding-right: 0;
       padding-top: 15px;
 

--- a/src/app/integrations/create-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.scss
@@ -8,142 +8,16 @@
     justify-content: space-between;
   }
 
-  ul {
-    list-style-type: none;
-    -webkit-margin-before: 0;
-
-    li {
-      list-style-type: none;
-    }
-  }
-
   .bold {
     font-weight: bold;
   }
 
-  // Integration Name Editor
   .name {
-    //border-bottom: 2px solid #D0D0D0;
     font-style: italic;
-    //margin-top: -10px;
-    //padding-bottom: 5px;
   }
 
   // Steps on left-hand side
   .steps {
-    //margin-right: 65px;
-    //padding-top: 20px;
-
-    // Left-hand side design with the cube and line
-    .progress-line {
-      //padding-right: 0;
-      text-align: center;
-
-      ul {
-        padding-right: 35px;
-        -webkit-padding-start: 0;
-
-        li {
-          padding-left: 5px;
-        }
-      }
-
-      // Used for the containing <div> around any cubes to make e2e testing easier
-      .icon {
-        padding-top: 0px;
-        // Overriding the actual cube icon's colors
-        .fa {
-          color: #D1D1D1;
-          font-size: x-large;
-        }
-
-        .round {
-          -moz-border-radius: 100px;
-          border-radius: 100px;
-          padding: 11px;
-          width: 55px;
-          height: 55px;
-
-          &.active {
-            border: 3px solid #1487CB;
-          }
-
-          &.inactive {
-            border: 3px solid #D0D0D0;
-          }
-        }
-      }
-
-      // Line that connects cubes
-      .vertical {
-        border: 2px solid #D0D0D0;
-        height: 200px;
-        left: 40px;
-        margin-top: -10px;
-        position: absolute;
-        width: 0;
-      }
-    }
-
-    // Right-hand side collapsible text menu
-    .text {
-      padding-left: 0;
-      padding-right: 0;
-      padding-top: 15px;
-
-      ul {
-        cursor: pointer;
-        padding-right: 35px;
-        -webkit-padding-start: 0;
-
-        li {
-          //padding-left: 5px;
-
-          &:hover {
-            //background-color:
-          }
-        }
-      }
-
-      .start, .finish {
-        h5 {
-          background-color: #EDEDED;
-          cursor: pointer;
-          display: inline;
-          padding: 5px;
-          text-transform: uppercase;
-        }
-
-        ul {
-          min-width: 160px;
-          padding: 10px 0;
-
-          // Sub-Menu Items
-          &.collapse {
-            margin-top: 5px;
-            padding: 5px 0;
-
-            li {
-              padding: 5px 5px 5px 17px;
-
-              &.active {
-                background-color: #D6EEFA;
-                border-bottom: 1px solid #B8DFF3;
-                border-top: 1px solid #B8DFF3;
-              }
-
-              &.inactive {
-                color: #D1D1D1;
-              }
-            }
-          }
-        }
-
-        .fa {
-          font-size: x-small;
-          padding-right: 5px;
-        }
-      }
-    }
+    flex-wrap: nowrap;
   }
 }

--- a/src/app/integrations/create-page/flow-view/flow-view.component.spec.ts
+++ b/src/app/integrations/create-page/flow-view/flow-view.component.spec.ts
@@ -8,6 +8,7 @@ import { TabsModule } from 'ng2-bootstrap';
 import { RestangularModule } from 'ng2-restangular';
 
 import { FlowViewComponent } from './flow-view.component';
+import { FlowViewStepComponent } from './flow-view-step.component';
 import { IntegrationStore } from '../../../store/integration/integration.store';
 import { IntegrationService } from '../../../store/integration/integration.service';
 import { CurrentFlow } from '../current-flow.service';
@@ -33,6 +34,7 @@ describe('IntegrationsCreateComponent', () => {
       ],
       declarations: [
         FlowViewComponent,
+        FlowViewStepComponent,
       ],
       providers: [
         MockBackend,

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -17,6 +17,7 @@ import { IntegrationsListToolbarComponent } from './list-toolbar/list-toolbar.co
 import { IntegrationsFilterPipe } from './integrations-filter.pipe';
 import { IntegrationsListComponent } from './list/list.component';
 import { FlowViewComponent } from './create-page/flow-view/flow-view.component';
+import { FlowViewStepComponent } from './create-page/flow-view/flow-view-step.component';
 import { CurrentFlow } from './create-page/current-flow.service';
 import { IPaaSCommonModule } from '../common/common.module';
 import { ConnectionsModule } from '../connections/connections.module';
@@ -66,6 +67,7 @@ const routes: Routes = [
     IntegrationsListComponent,
     IntegrationsFilterPipe,
     FlowViewComponent,
+    FlowViewStepComponent,
   ],
   providers: [
     CurrentFlow,


### PR DESCRIPTION
Wanted to first off get the flow view thingie to handle more than 2 steps :-)

I reorganized the elements a bit (kept the old markup commented out for now) to use an `*ngFor` for the steps in the integration.  I haven't handled the line that connects the icons and left it out for now, I think we'll need to figure out a good generic approach to that as we'll quickly start getting more complicated flows to visualize.  Anyhoo, screenshot:

![fireshot capture 2 - red hat ipaas - http___localhost_4200_integrations_edit_1_connection-select_0](https://cloud.githubusercontent.com/assets/351660/23231239/18d74330-f915-11e6-950a-f7948cfa0ba0.png)
