### PR TITLE
Two phase OAuth flow to support OpenShift and GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/router": "3.4.7",
     "@ng2-dynamic-forms/core": "1.3.13",
     "@ng2-dynamic-forms/ui-bootstrap": "1.3.13",
-    "angular-oauth2-oidc-hybrid": "1.0.22",
+    "angular-oauth2-oidc-hybrid": "1.0.26",
     "angular2-toaster": "2.0.0",
     "bootstrap": "3.3.7",
     "core-js": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,9 +243,9 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-angular-oauth2-oidc-hybrid@1.0.22:
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/angular-oauth2-oidc-hybrid/-/angular-oauth2-oidc-hybrid-1.0.22.tgz#072fc438b7c294dab0d12e94e98f3aab23b84d66"
+angular-oauth2-oidc-hybrid@1.0.26:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/angular-oauth2-oidc-hybrid/-/angular-oauth2-oidc-hybrid-1.0.26.tgz#19d5d055423c9d1d37c2a55914874df956d9cba3"
   dependencies:
     base64-js "^1.2.0"
     js-base64 "^2.1.9"


### PR DESCRIPTION
I'd like to merge this ASAP but this will break any local use due to the single
redirect policy for GitHub OAuth apps. Would appreciate help coming to right
solution so we don't break everyone.

3 potential solutions:

1. Each dev have their own oauth app pointing at whatever local redirect URL they
want. This is my preferred option to be honest as it's most flexible but is also
hardest to set up for new contributors.

2. Each dev use the same URL locally and a single oauth application. This would
work but coming up with a URL that works for everyone might prove tricky. Also
have to share oauth app secrets somehow. Not good for new contributors perhaps.

3. Set up a @chirino's redirector that can be used to redirect to local app. Not sure I like
this as it goes against normal oauth flow.

We can always do something for now and come up with a better solution later.

Thoughts @gashcrumb @kahboom @chirino ?