### PR TITLE
Read/save values into the config string

### DIFF
--- a/src/app/common/forms.service.ts
+++ b/src/app/common/forms.service.ts
@@ -28,6 +28,7 @@ export class FormFactoryService {
             label: value.title || value.displayName || value.name || key,
             hint: value.description,
             inputType: type,
+            value: value.value || value.defaultValue,
           });
           break;
         default:


### PR DESCRIPTION
For now (this will all need adjusting) we'll save/read values from 'configuredProperties', so now connections actually save their values, for example:

![screencapture-localhost-4200-connections-6-1488555766545](https://cloud.githubusercontent.com/assets/351660/23557592/89a3fc30-fffe-11e6-99f1-6fea92663a31.png)
