### PR TITLE
Add links to insert steps/connections

### DIFF
--- a/src/app/integrations/edit-page/edit-page.component.ts
+++ b/src/app/integrations/edit-page/edit-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
@@ -31,11 +31,12 @@ export class IntegrationsEditPage implements OnInit, OnDestroy {
   constructor( private currentFlow: CurrentFlow,
               private store: IntegrationStore,
               private route: ActivatedRoute,
-              private router: Router ) {
+              private router: Router,
+              private detector: ChangeDetectorRef,
+               ) {
     this.integration = this.store.resource;
     this.loading = this.store.loading;
   }
-
 
   getCurrentChild(): string {
     const child = this.route.firstChild;
@@ -72,6 +73,7 @@ export class IntegrationsEditPage implements OnInit, OnDestroy {
     switch (event.kind) {
       case 'integration-updated':
         this.router.navigate(['save-or-add-step'], { relativeTo: this.route });
+        this.detector.detectChanges();
         break;
       case 'integration-no-actions':
         break;

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.html
@@ -12,7 +12,6 @@
         </div>
       </div>
     </div>
-
     <div class="flow-view-container" *ngIf="i && i.steps">
       <div class="row steps start">
         <ipaas-integrations-flow-view-step
@@ -21,17 +20,27 @@
           [currentPosition]="currentPosition"
           [currentState]="currentState"></ipaas-integrations-flow-view-step >
       </div>
-      <div class="row steps" *ngFor="let step of getMiddleSteps(); let position = index;">
-        <div *ngIf="currentPosition === 'new'">
-          New</div>
+      <div class="row steps" *ngIf="currentState === 'save-or-add-step'">
+        <ul>
+          <li><a (click)="insertStepAfter(0)">Add a step</a></li>
+          <li><a (click)="insertConnectionAfter(0)">Add a connection</a></li>
+        </ul>
+      </div>
+      <template ngFor let-step [ngForOf]="getMiddleSteps()" let-position="index">
+      <div class="row steps">
         <ipaas-integrations-flow-view-step
           [step]="step"
           [position]="position + 1"
           [currentPosition]="currentPosition"
           [currentState]="currentState"></ipaas-integrations-flow-view-step >
-        <div *ngIf="currentPosition === 'new'">
-          New</div>
       </div>
+      <div class="row steps" *ngIf="currentState === 'save-or-add-step'">
+        <ul>
+          <li><a (click)="insertStepAfter(position + 1)">Add a step</a></li>
+          <li><a (click)="insertConnectionAfter(position + 1)">Add a connection</a></li>
+        </ul>
+      </div>
+      </template>
       <div class="row steps finish">
         <ipaas-integrations-flow-view-step
           [step]="endConnection()"

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.ts
@@ -5,7 +5,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { log, getCategory } from '../../../logging';
 import { CurrentFlow, FlowEvent } from '../current-flow.service';
-import { Integration, Step } from '../../../model';
+import { Integration, Step, TypeFactory } from '../../../model';
 
 const category = getCategory('IntegrationsCreatePage');
 
@@ -60,6 +60,21 @@ export class FlowViewComponent implements OnInit, OnDestroy {
 
   getMiddleSteps() {
     return this.currentFlow.getMiddleSteps();
+  }
+
+  insertStepAfter(position: number) {
+    const target = position + 1;
+    const step = TypeFactory.createStep();
+    this.currentFlow.steps.splice(target, 0, step);
+    this.router.navigate(['step-select', target], { relativeTo: this.route });
+  }
+
+  insertConnectionAfter(position: number) {
+    const target = position + 1;
+    const step = TypeFactory.createStep();
+    step.stepKind = 'endpoint';
+    this.currentFlow.steps.splice(target, 0, step);
+    this.router.navigate(['connection-select', target], { relativeTo: this.route });
   }
 
   integrationNameChanged($event) {

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -74,7 +74,7 @@ export class IntegrationsSaveOrAddStepComponent implements OnInit, OnDestroy {
     this.flowSubscription = this.currentFlow.events.subscribe((event: FlowEvent) => {
       this.handleFlowEvent(event);
     });
-    this.validateFlow();
+    //this.validateFlow();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This adds the links that let you add a step or connection to a flow.  They only show up on this page.  I think BTW that the buttons in the main view make no sense as there's no context to figure out where a step/connection should be added in the flow, unlike the inlined links.  Something to discuss with UX.

![screencapture-localhost-4200-integrations-edit-2-save-or-add-step-1489096269977](https://cloud.githubusercontent.com/assets/351660/23772336/9c533aa0-04e8-11e7-973d-bcf6bec4cd18.png)
