### PR TITLE
Add Toast notification and modal for deactivation and activation

### DIFF
--- a/src/app/integrations/list/list.component.html
+++ b/src/app/integrations/list/list.component.html
@@ -11,6 +11,80 @@
 
       <!-- Toast Notification Container -->
       <toaster-container></toaster-container>
+  
+      <!-- Activate Modal Container -->
+      <div bsModal
+           #childModal="bs-modal"
+           class="modal fade"
+           tabindex="-1"
+           role="dialog"
+           aria-labelledby="activateModal"
+           aria-hidden="true">
+        <div class="modal-dialog modal-md">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title pull-left">Confirm Activation</h4>
+              <button type="button"
+                      class="close pull-right"
+                      aria-label="Close"
+                      (click)="hideModal()">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div>
+                <p>Are you sure you would like to activate the following integration?</p>
+              </div>
+              <div style="text-align: center; font-weight: 700">
+                <p>{{ integration['name'] }}</p>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="pull-right btn btn-primary"
+                      (click)="activateAction(integration)">Activate</button>
+              <button class="pull-right btn btn-cancel"
+                      (click)="hideModal()">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
+  
+      <!-- Deactivate Modal Container -->
+      <div bsModal
+           #childModal="bs-modal"
+           class="modal fade"
+           tabindex="-1"
+           role="dialog"
+           aria-labelledby="deactivateModal"
+           aria-hidden="true">
+        <div class="modal-dialog modal-md">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title pull-left">Confirm Deactivation</h4>
+              <button type="button"
+                      class="close pull-right"
+                      aria-label="Close"
+                      (click)="hideModal()">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div>
+                <p>Are you sure you would like to deactivate the following integration?</p>
+              </div>
+              <div style="text-align: center; font-weight: 700">
+                <p>{{ integration['name'] }}</p>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="pull-right btn btn-primary"
+                      (click)="deactivateAction(integration)">Deactivate</button>
+              <button class="pull-right btn btn-cancel"
+                      (click)="hideModal()">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <!-- Delete Modal Container -->
       <div bsModal
@@ -98,14 +172,17 @@
               <a [routerLink]=" ['edit', integration.id, 'save-or-add-step'] ">Edit</a>
             </li>
             <li>
-              <a>Deactivate</a>
+              <a (click)="requestDeactivate(integration)">Deactivate</a>
             </li>
-            <li *ngIf="integration.active === false">
+            <li *ngIf="integration.active === false"
+                (click)="requestActivate(integration)">
               <a>Activate</a>
             </li>
+            <!--
             <li>
               <a>Duplicate</a>
             </li>
+            -->
             <li>
               <a (click)="requestDelete(integration)">Delete</a>
             </li>

--- a/src/app/integrations/list/list.component.ts
+++ b/src/app/integrations/list/list.component.ts
@@ -30,24 +30,49 @@ export class IntegrationsListComponent {
 
   //-----  Activate/Deactivate ------------------->>
 
-  // Open modal to confirm delete
-  requestToggleActivation(integration: Integrations) {
-    log.debugc(() => 'Selected integration for delete: ' + JSON.stringify(integration['id']));
+  // TODO: Refactor into single method for both cases
+  // Open modal to confirm activation
+  requestActivate(integration: Integrations) {
+    log.debugc(() => 'Selected integration for activation: ' + JSON.stringify(integration['id']));
     this.showModal();
   }
 
+  // Open modal to confirm deactivation
+  requestDeactivate(integration: Integrations) {
+    log.debugc(() => 'Selected integration for deactivation: ' + JSON.stringify(integration['id']));
+    this.showModal();
+  }
+
+  // TODO: Refactor into single method for both cases
   // Actual activate/deactivate action once the user confirms
-  toggleActivateAction(integration: Integrations) {
-    log.debugc(() => 'Selected integration for delete: ' + JSON.stringify(integration['id']));
+  activateAction(integration: Integrations) {
+    log.debugc(() => 'Selected integration for activation: ' + JSON.stringify(integration['id']));
 
     this.hideModal();
 
-    //this.store.deleteEntity(integration['id']);
+    //this.store.activate(integration['id']);
 
     this.toast = {
       type: 'success',
-      title: '',
-      body: '',
+      title: 'Integration is activating',
+      body: 'Please allow a moment for the integration to fully activate.',
+    };
+
+    setTimeout(this.popToast(this.toast), 1000);
+  }
+
+  // Actual activate/deactivate action once the user confirms
+  deactivateAction(integration: Integrations) {
+    log.debugc(() => 'Selected integration for deactivation: ' + JSON.stringify(integration['id']));
+
+    this.hideModal();
+
+    //this.store.deactivate(integration['id']);
+
+    this.toast = {
+      type: 'success',
+      title: 'Integration is deactivating',
+      body: 'Please allow a moment for the integration to be deactivated.',
     };
 
     setTimeout(this.popToast(this.toast), 1000);


### PR DESCRIPTION
Add methods for toast notifications and modal confirmations for activating and deactivating an integration.

There is currently an issue where it selects the wrong modal, and also the toast notifications need to be styled, but, hey, it's a start:

<img width="1439" alt="screenshot 2017-03-10 00 30 32" src="https://cloud.githubusercontent.com/assets/3844502/23783356/113b739c-0529-11e7-8942-850848699542.png">

<img width="1440" alt="screenshot 2017-03-10 00 30 44" src="https://cloud.githubusercontent.com/assets/3844502/23783357/146dab84-0529-11e7-9b3f-df46e1a6ac55.png">

<img width="1437" alt="screenshot 2017-03-10 00 30 47" src="https://cloud.githubusercontent.com/assets/3844502/23783359/17ba53d2-0529-11e7-821e-03e9e47acce1.png">
