### PR TITLE
Fix #281, missed a spot saving configuredProperties for steps vs connections

### DIFF
--- a/src/app/integrations/edit-page/current-flow.service.ts
+++ b/src/app/integrations/edit-page/current-flow.service.ts
@@ -114,8 +114,9 @@ export class CurrentFlow {
       case 'integration-set-step':
         {
           const position = +event['position'];
-          const step = event['step'];
-          this.steps[position] = step;
+          const step = <Step> event['step'];
+          this.steps[position] = TypeFactory.createStep();
+          this.steps[position].stepKind = step.stepKind;
           this.maybeDoAction(event['onSave']);
           log.debugc(() => 'Set step at position: ' + position, category);
         }

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -1,5 +1,5 @@
 <div class="save-or-add-step">
-  
+
   <!-- Toolbar -->
   <div class="toolbar">
     <!-- Toolbar: Breadcrumbs -->
@@ -20,15 +20,19 @@
             </button>
             &nbsp;
             <button type="button"
-                    class="btn btn-primary"
+                    class="btn btn-default"
                     (click)="save()">Save
+            </button>
+            <button type="button"
+                    class="btn btn-primary"
+                    (click)="saveAndPublish()">Publish
             </button>
           </div>
         </div>
       </div>
     </div>
   </div>
-  
+
   <!-- Content -->
   <div class="wizard-pf-body clearfix">
     <div class="blank-slate-pf">

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -29,6 +29,16 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
   goBack() { /* this should be a no-op */ }
 
   save() {
+    this.currentFlow.integration.statusType = 'Deactivated';
+    this.doSave();
+  }
+
+  saveAndPublish() {
+    this.currentFlow.integration.statusType = 'Activated';
+    this.doSave();
+  }
+
+  doSave() {
     const router = this.router;
     this.currentFlow.events.emit({
       kind: 'integration-save',

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.ts
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.ts
@@ -55,7 +55,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage implements OnIn
     this.currentFlow.events.emit({
       kind: 'integration-set-properties',
       position: this.position,
-      properties: JSON.stringify(properties),
+      properties: properties,
       onSave: () => {
         this.router.navigate(['save-or-add-step'], { queryParams: { validate: true }, relativeTo: this.route.parent });
       },


### PR DESCRIPTION
Also for the moment add a separate 'Save' and 'Publish' button so you can save an integration as activated or deactivated from the editor at least.