### PR TITLE
Make the integration basics page only show up if the integration isn't named

### DIFF
--- a/src/app/integrations/edit-page/integration-basics/integration-basics.component.html
+++ b/src/app/integrations/edit-page/integration-basics/integration-basics.component.html
@@ -53,9 +53,7 @@
         </div>
       </div>
       <div class="form-group">
-        <label class="col-xs-2 control-label">Description&nbsp;
-          <span style="color: red">*</span>
-        </label>
+        <label class="col-xs-2 control-label">Description</label>
         <div class="col-xs-7">
           <textarea data-id="descriptionInput"
                     name="descriptionInput"

--- a/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
+++ b/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
@@ -22,8 +22,7 @@ export class IntegrationBasicsComponent extends FlowPage {
   }
 
   canContinue() {
-    return this.currentFlow.integration.name && this.currentFlow.integration.name !== '' &&
-           this.currentFlow.integration.description && this.currentFlow.integration.description !== '';
+    return this.currentFlow.integration.name && this.currentFlow.integration.name !== '';
   }
 
   continue() {

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -39,6 +39,10 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
   }
 
   doSave() {
+    if (!this.currentFlow.integration.name || this.currentFlow.integration.name === '') {
+      this.router.navigate(['integration-basics'], { relativeTo: this.route.parent });
+      return;
+    }
     const router = this.router;
     this.currentFlow.events.emit({
       kind: 'integration-save',
@@ -52,11 +56,6 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
   }
 
   validateFlow() {
-    if (!this.currentFlow.integration.name || this.currentFlow.integration.name === '' ||
-        !this.currentFlow.integration.description || this.currentFlow.integration.description === '') {
-      this.router.navigate(['integration-basics'], { relativeTo: this.route.parent });
-      return;
-    }
     if (this.currentFlow.getStartConnection() === undefined) {
       this.router.navigate(['connection-select', this.currentFlow.getFirstPosition()], { relativeTo: this.route.parent });
       return;


### PR DESCRIPTION
At least until we get auto-naming implemented.  So now you get prompted for the name if you haven't set it before saving the integration.