### PR TITLE
Hide 'choose connection/action/step' once the user has gone through those pages

### DIFF
--- a/src/app/integrations/edit-page/action-configure/action-configure.component.ts
+++ b/src/app/integrations/edit-page/action-configure/action-configure.component.ts
@@ -39,6 +39,8 @@ export class IntegrationsConfigureActionComponent extends FlowPage implements On
   }
 
   goBack() {
+    const step = this.currentFlow.getStep(this.position);
+    step.action = undefined;
     super.goBack(['action-select', this.position]);
   }
 

--- a/src/app/integrations/edit-page/connection-select/connection-select.component.ts
+++ b/src/app/integrations/edit-page/connection-select/connection-select.component.ts
@@ -58,6 +58,8 @@ export class IntegrationsSelectConnectionComponent extends FlowPage implements O
   }
 
   goBack() {
+    const step = this.currentFlow.getStep(this.position);
+    step.connection = undefined;
     super.goBack(['save-or-add-step']);
   }
 
@@ -81,6 +83,7 @@ export class IntegrationsSelectConnectionComponent extends FlowPage implements O
         });
       })
       .subscribe();
+    /*
     this.connections.map((connections: Connections) => {
       const config = this.currentFlow.getStep(this.position);
       if (config) {
@@ -92,6 +95,7 @@ export class IntegrationsSelectConnectionComponent extends FlowPage implements O
         }
       }
     });
+    */
     this.store.loadAll();
   }
 

--- a/src/app/integrations/edit-page/edit-page.component.html
+++ b/src/app/integrations/edit-page/edit-page.component.html
@@ -1,25 +1,17 @@
-<div class="integrations edit">
-  <div class="wizard-pf-row">
+<ipaas-loading [loading]="!(integration | async)">
+  <div class="integrations edit" *ngIf="integration | async">
+    <div class="wizard-pf-row">
 
-    <!-- Sidebar -->
-    <div class="wizard-pf-sidebar">
-      <ipaas-integrations-flow-view></ipaas-integrations-flow-view>
-    </div>
-
-
-    <!-- Add/Edit Integration -->
-    <div class="wizard-pf-main">
-      <router-outlet></router-outlet>
-
-      <!-- Wizard Footer -->
-      <!--
-      <div class='wizard-pf-footer'>
-        <button type='button' class='btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss' (click)="cancel()">Cancel</button>
-        <button type="button" class="btn btn-default" *ngIf="showBack()" (click)="goBack()"><i class="fa fa-chevron-left"></i> Back</button>
-        <button type="button" class="btn btn-primary" *ngIf="showNext()" [disabled]="!canContinue()" (click)="continue()" >Next <i class="fa fa-chevron-right"></i></button>
-        <button type="button" class="btn btn-primary" *ngIf="showFinish()" [disabled]="!canFinish()" (click)="finish()">Create</button>
+      <!-- Sidebar -->
+      <div class="wizard-pf-sidebar">
+        <ipaas-integrations-flow-view></ipaas-integrations-flow-view>
       </div>
-      -->
+
+      <!-- Add/Edit Integration -->
+      <div class="wizard-pf-main">
+        <router-outlet></router-outlet>
+
+      </div>
     </div>
   </div>
-</div>
+</ipaas-loading>

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -49,22 +49,25 @@
       <!-- Delete Icon -->
       <i class="delete-icon fa fa-lg fa-trash"
          (click)="deletePrompt()"></i>
-      
-      <span [class]="getParentClass() + ' step-heading'" (click)="goto()">
+
+      <span [class]="getParentClass() + ' step-heading'" (click)="goto('action-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
         <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
         {{ getStepText() }}
       </span>
 
       <ul [collapse]="isCollapsed()">
-        <li [class]="getSubMenuActiveClass('connection-select')" (click)="goto('connection-select')">
+        <li *ngIf="!step.connection" [class]="getSubMenuActiveClass('connection-select')" (click)="goto('connection-select')">
           <span [class]="getTextClass('connection-select')">Choose a connection</span>
         </li>
-        <li [class]="getSubMenuActiveClass('action-select')" (click)="goto('action-select')">
+        <li *ngIf="!step.action" [class]="getSubMenuActiveClass('action-select')" (click)="goto('action-select')">
           <span [class]="getTextClass('action-select')">Choose an action</span>
         </li>
-        <li [class]="getSubMenuActiveClass('action-configure')" (click)="goto('action-configure')">
+        <li *ngIf="!step.configuredProperties" [class]="getSubMenuActiveClass('action-configure')" (click)="goto('action-configure')">
           <span [class]="getTextClass('action-configure')">Configure the action</span>
+        </li>
+        <li *ngIf="step.configuredProperties" [class]="getSubMenuActiveClass('action-configure')" (click)="goto('action-configure')">
+          <span [class]="getTextClass('action-configure')">Configure</span>
         </li>
       </ul>
 
@@ -76,18 +79,21 @@
       <i class="delete-icon fa fa-lg fa-trash"
          [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')"
          (click)="deleteStep()"></i>
-      <span [class]="getParentClass() + ' step-heading'" (click)="goto()">
+      <span [class]="getParentClass() + ' step-heading'" (click)="goto('step-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
         <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
         {{ getStepText() }}
       </span>
 
       <ul [collapse]="isCollapsed()">
-        <li [class]="getSubMenuActiveClass('step-select')" (click)="goto('step-select')">
+        <li *ngIf="!step.stepKind" [class]="getSubMenuActiveClass('step-select')" (click)="goto('step-select')">
           <span [class]="getTextClass('step-select')">Choose a step</span>
         </li>
-        <li [class]="getSubMenuActiveClass('step-configure')" (click)="goto('step-configure')">
+        <li *ngIf="!step.configuredProperties" [class]="getSubMenuActiveClass('step-configure')" (click)="goto('step-configure')">
           <span [class]="getTextClass('step-configure')">Configure the step</span>
+        </li>
+        <li *ngIf="step.configuredProperties" [class]="getSubMenuActiveClass('step-configure')" (click)="goto('step-configure')">
+          <span [class]="getTextClass('step-configure')">Configure</span>
         </li>
       </ul>
     </div>

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.ts
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.ts
@@ -40,6 +40,9 @@ export class IntegrationsStepConfigureComponent extends FlowPage implements OnIn
   }
 
   goBack() {
+    const step = this.currentFlow.getStep(this.position);
+    step.stepKind = undefined;
+    step.configuredProperties = undefined;
     super.goBack(['step-select', this.position]);
   }
 


### PR DESCRIPTION
This hides the 'Choose a Connection' and 'Choose an action' links on the left after the user has gone through those pages and defaults the parent item (connection or step name) to link to the 'Configure' page containing the form instead.

@kcbabo @chirino FYI