### PR TITLE
Create Integration Changes

### DIFF
--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -30,7 +30,7 @@
   <!-- Icon Progress Line -->
 
   <div class="col-md-3 progress-line">
-    <p [class]="'icon ' + getSubMenuActiveClass() + ' ' + getMenuCompleteClass()"
+    <p [class]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass()"
        [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')">
       <!-- Only display icon if step kind is not an endpoint or log -->
       <i [class]="getIconClass()"

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -30,7 +30,7 @@
   <!-- Icon Progress Line -->
 
   <div class="col-md-3 progress-line">
-    <p [class]="'icon ' + getSubMenuActiveClass()"
+    <p [class]="'icon ' + getSubMenuActiveClass() + getMenuCompleteClass()"
        [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')">
       <!-- Only display icon if step kind is not an endpoint or log -->
       <i [class]="getIconClass()"

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -30,7 +30,7 @@
   <!-- Icon Progress Line -->
 
   <div class="col-md-3 progress-line">
-    <p [class]="'icon ' + getSubMenuActiveClass() + getMenuCompleteClass()"
+    <p [class]="'icon ' + getSubMenuActiveClass() + ' ' + getMenuCompleteClass()"
        [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')">
       <!-- Only display icon if step kind is not an endpoint or log -->
       <i [class]="getIconClass()"

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="step" class="flow-view-step steps">
 
 <!-- Delete Modal Container -->
+
 <div bsModal #childModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteModal" aria-hidden="true">
   <div class="modal-dialog modal-md">
     <div class="modal-content">
@@ -42,11 +43,14 @@
 
   <!-- Progress Menu -->
 
-  <div class="col-md-9 text" *ngIf="currentStepKind !== 'datamapper'" [ngSwitch]="step.stepKind">
+  <div class="col-md-9 menu" *ngIf="currentStepKind !== 'datamapper'" [ngSwitch]="step.stepKind">
 
     <!-- Endpoint Steps -->
+    
     <div *ngSwitchCase="'endpoint'" [class]="getParentActiveClass()">
+      
       <!-- Delete Icon -->
+      
       <i class="delete-icon fa fa-lg fa-trash"
          (click)="deletePrompt()"></i>
 
@@ -74,11 +78,15 @@
     </div>
 
     <!-- Default Steps -->
+    
     <div *ngSwitchDefault [class]="getParentActiveClass()">
+      
       <!-- Delete Icon -->
+      
       <i class="delete-icon fa fa-lg fa-trash"
          [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')"
          (click)="deleteStep()"></i>
+      
       <span [class]="getParentClass() + ' step-heading'" (click)="goto('step-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
         <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="step" class="flow-view-step steps">
+<div *ngIf="step" class="flow-view-step">
 
 <!-- Delete Modal Container -->
 
@@ -30,14 +30,12 @@
   <!-- Icon Progress Line -->
 
   <div class="col-md-3 progress-line">
-    <div class="icon">
-      <p [class]="'round ' + getSubMenuActiveClass()"
-         [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')">
-        <!-- Only display icon if step kind is not an endpoint or log -->
-        <i [class]="getIconClass()"
-           *ngIf="step.stepKind === ('endpoint' || 'log')"></i>
-      </p>
-    </div>
+    <p [class]="'icon ' + getSubMenuActiveClass()"
+       [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')">
+      <!-- Only display icon if step kind is not an endpoint or log -->
+      <i [class]="getIconClass()"
+         *ngIf="step.stepKind === ('endpoint' || 'log')"></i>
+    </p>
   </div>
 
 
@@ -47,20 +45,26 @@
 
     <!-- Endpoint Steps -->
     
-    <div *ngSwitchCase="'endpoint'" [class]="getParentActiveClass()">
+    <div *ngSwitchCase="'endpoint'" [class]="getParentActiveClass() + ' step-container'">
       
       <!-- Delete Icon -->
       
       <i class="delete-icon fa fa-lg fa-trash"
          (click)="deletePrompt()"></i>
 
-      <span [class]="getParentClass() + ' step-heading'" (click)="goto('action-configure')">
+      
+      <!-- Parent Step -->
+      
+      <span [class]="getParentClass()" (click)="goto('action-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
         <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
         {{ getStepText() }}
       </span>
 
-      <ul [collapse]="isCollapsed()">
+      
+      <!-- Sub Steps -->
+      
+      <ul [collapse]="isCollapsed()" class="sub-steps">
         <li *ngIf="!step.connection" [class]="getSubMenuActiveClass('connection-select')" (click)="goto('connection-select')">
           <span [class]="getTextClass('connection-select')">Choose a connection</span>
         </li>
@@ -79,7 +83,7 @@
 
     <!-- Default Steps -->
     
-    <div *ngSwitchDefault [class]="getParentActiveClass()">
+    <div *ngSwitchDefault [class]="getParentActiveClass() + ' step-container'">
       
       <!-- Delete Icon -->
       
@@ -87,13 +91,17 @@
          [class.add-step-or-connection]="step.stepKind !== ('endpoint' || 'log')"
          (click)="deleteStep()"></i>
       
-      <span [class]="getParentClass() + ' step-heading'" (click)="goto('step-configure')">
+      <!-- Parent Step Heading -->
+      
+      <span [class]="getParentClass()" (click)="goto('step-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
         <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
         {{ getStepText() }}
       </span>
 
-      <ul [collapse]="isCollapsed()">
+      <!-- Sub Steps -->
+      
+      <ul [collapse]="isCollapsed()" class="sub-steps">
         <li *ngIf="!step.stepKind" [class]="getSubMenuActiveClass('step-select')" (click)="goto('step-select')">
           <span [class]="getTextClass('step-select')">Choose a step</span>
         </li>

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -1,7 +1,25 @@
 @import 'flow-view.component';
 @import '../../../../scss/colors';
 
+////////////////////////////////////////////////////////////////////////////////
+// FLOW-VIEW-STEP
+//
+// 2 Primary State Categories:
+//
+// 1 - Active/Inactive - Is the user currently on this section/step?
+// 2 - Complete/Incomplete - Has the user completed/configured this section/step?
+//
+// 03/24/2017
+// This file is now organized first by section, then by state (ie text/icon then active/inactive). RMY
+//
+////////////////////////////////////////////////////////////////////////////////
+
 .flow-view-step {
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // SIDEBAR: COMMON, REGARDLESS OF STATE
+  ////////////////////////////////////////////////////////////////////////////////
+
   flex-wrap: nowrap;
 
   ul {
@@ -20,7 +38,15 @@
     cursor: pointer;
   }
 
-  // Left-hand side design with the icon and line
+
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // SIDEBAR: LEFT HAND (ICON & PROGRESS LINE)
+  ////////////////////////////////////////////////////////////////////////////////
+
+  //----- Progress Line ----------------->>
+
   .progress-line {
     text-align: center;
 
@@ -32,17 +58,7 @@
         padding-left: 5px;
       }
     }
-
-    // Line that connects cubes
-    .vertical {
-      border: 2px solid #D0D0D0;
-      height: 200px;
-      left: 40px;
-      margin-top: -10px;
-      position: absolute;
-      width: 0;
-    }
-
+    
     .icon {
       padding-top: 0;
       // Overriding the actual cube icon's colors
@@ -80,11 +96,35 @@
     }
   }
 
-  .text {
+  ////////////////////////////////////////////////////////////////////////////////
+  // SIDEBAR: RIGHT HAND (PROGRESS MENU)
+  ////////////////////////////////////////////////////////////////////////////////
+
+  .menu {
     position: relative;
     padding-left: 0;
     padding-right: 0;
     padding-top: 19px;
+
+
+    //----- Sidebar: Menu: Active State ----------------->>
+
+    &.active {}
+
+
+    //----- Sidebar: Menu: Inactive State ----------------->>
+
+    &.inactive {}
+
+
+    //----- Sidebar: Menu: Complete State ----------------->>
+
+    &.complete {}
+
+
+    //----- Sidebar: Menu: Incomplete State ----------------->>
+
+    &.incomplete {}
 
     ul {
       min-width: 160px;
@@ -92,6 +132,7 @@
       -webkit-padding-start: 0;
 
       // Sub-Menu Items
+
       &.collapse {
         margin-top: 5px;
         padding: 5px 0;

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -57,13 +57,14 @@
     .icon {
       -moz-border-radius: 100px;
       border-radius: 100px;
+      border: 3px solid #d0d0d0;
       padding: 11px;
       width: 55px;
       height: 55px;
-      background-color: white;
+      background-color: #FFFFFF;
 
       &.add-step-or-connection {
-        background-color: #fff;
+        background-color: #FFFFFF;
         border: 10px solid $pf-blue-400;
         border-radius: 100px;
         height: 33px;
@@ -72,6 +73,13 @@
         width: 32px;
       }
     }
+
+    // Vertical Line
+
+    .step-line {
+      height: 100%;
+    }
+
 
     //----- Sidebar: Progress Line: Active State ----------------->>
 
@@ -93,13 +101,22 @@
 
     //----- Sidebar: Progress Line: Complete State ----------------->>
 
-    &.complete {}
+    &.complete {
+      .icon {}
+    }
 
 
     //----- Sidebar: Progress Line: Incomplete State ----------------->>
 
-    &.incomplete {}
+    &.incomplete {
+      .icon {
+        border: 3px solid #d0d0d0;
+      }
+    }
   }
+
+
+
 
   ////////////////////////////////////////////////////////////////////////////////
   // SIDEBAR: RIGHT HAND (PROGRESS MENU)
@@ -130,8 +147,6 @@
           color: #FFFFFF;
         }
       }
-
-
 
       //----- Sidebar: Menu: Parent Step ----------------->>
 
@@ -188,6 +203,7 @@
         li {
           display: list-item;
           list-style-type: none;
+          margin: 7px 0 0 0;
           padding: 5px 5px 5px 30px;
 
 

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -42,58 +42,63 @@
 
 
   ////////////////////////////////////////////////////////////////////////////////
-  // SIDEBAR: LEFT HAND (ICON & PROGRESS LINE)
+  // SIDEBAR: LEFT HAND (VERTICAL PROGRESS LINE & ICON)
   ////////////////////////////////////////////////////////////////////////////////
 
-  //----- Progress Line ----------------->>
-
   .progress-line {
+    padding-top: 0;
     text-align: center;
 
-    ul {
-      padding-right: 35px;
-      -webkit-padding-start: 0;
-
-      li {
-        padding-left: 5px;
-      }
+    .fa {
+      color: #D1D1D1;
+      font-size: x-large;
     }
-    
+
     .icon {
-      padding-top: 0;
-      // Overriding the actual cube icon's colors
-      .fa {
-        color: #D1D1D1;
-        font-size: x-large;
-      }
+      -moz-border-radius: 100px;
+      border-radius: 100px;
+      padding: 11px;
+      width: 55px;
+      height: 55px;
+      background-color: white;
 
-      .round {
-        -moz-border-radius: 100px;
+      &.add-step-or-connection {
+        background-color: #fff;
+        border: 10px solid $pf-blue-400;
         border-radius: 100px;
-        padding: 11px;
-        width: 55px;
-        height: 55px;
-        background-color: white;
-
-        &.active {
-          border: 3px solid $pf-blue-400;
-        }
-
-        &.inactive {
-          border: 3px solid #D0D0D0;
-        }
-
-        &.add-step-or-connection {
-          background-color: #fff;
-          border: 10px solid $pf-blue-400;
-          border-radius: 100px;
-          height: 33px;
-          margin: 11px;
-          padding: 0;
-          width: 32px;
-        }
+        height: 33px;
+        margin: 11px;
+        padding: 0;
+        width: 32px;
       }
     }
+
+    //----- Sidebar: Progress Line: Active State ----------------->>
+
+    &.active {
+      .icon {
+        border: 3px solid $pf-blue-400;
+      }
+    }
+
+
+    //----- Sidebar: Progress Line: Inactive State ----------------->>
+
+    &.inactive {
+      .icon {
+        border: 3px solid #D0D0D0;
+      }
+    }
+
+
+    //----- Sidebar: Progress Line: Complete State ----------------->>
+
+    &.complete {}
+
+
+    //----- Sidebar: Progress Line: Incomplete State ----------------->>
+
+    &.incomplete {}
   }
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -107,89 +112,110 @@
     padding-top: 19px;
 
 
-    //----- Sidebar: Menu: Active State ----------------->>
+    //----- Sidebar: Menu & Parent Step Container ----------------->>
 
-    &.active {}
+    .step-container {
 
-
-    //----- Sidebar: Menu: Inactive State ----------------->>
-
-    &.inactive {}
-
-
-    //----- Sidebar: Menu: Complete State ----------------->>
-
-    &.complete {}
+      .fa.fa-chevron-down, .fa.fa-chevron-right {
+        font-size: x-small;
+        padding-right: 5px;
+        margin-right: 5px;
+      }
 
 
-    //----- Sidebar: Menu: Incomplete State ----------------->>
+      // Active State for Entire Container of Single Step
 
-    &.incomplete {}
+      &.active {
+        .fa.fa-trash {
+          color: #FFFFFF;
+        }
+      }
 
-    ul {
-      min-width: 160px;
-      padding: 10px 35px 0 0;
-      -webkit-padding-start: 0;
 
-      // Sub-Menu Items
 
-      &.collapse {
+      //----- Sidebar: Menu: Parent Step ----------------->>
+
+      .parent-step {
+        background-color: #E7E7E7;
+        cursor: pointer;
+        display: inline;
+        padding: 8px 100% 8px 8px;
+        text-transform: uppercase;
+
+
+        //----- Sidebar: Menu: Parent Step: Active State ----------------->>
+
+        &.active {
+          background-color: #158ACC;
+          color: #FFFFFF;
+        }
+
+
+        //----- Sidebar: Menu: Parent Step: Inactive State ----------------->>
+
+        &.inactive {}
+
+
+        //----- Sidebar: Menu: Parent Step: Complete State ----------------->>
+
+        &.complete {}
+
+
+        //----- Sidebar: Menu: Parent Step: Incomplete State ----------------->>
+
+        &.incomplete {}
+      }
+
+
+
+      //----- Sidebar: Menu: Sub Steps ----------------->>
+
+      ul.sub-steps {
+        cursor: default;
+        list-style-type: none;
+        margin-bottom: 10px;
         margin-top: 5px;
+        min-width: 160px;
         padding: 5px 0;
+        -webkit-margin-before: 0;
+        -webkit-margin-after: 1em;
+        -webkit-margin-start: 0;
+        -webkit-margin-end: 0;
+
+
+        // Each Step
 
         li {
+          display: list-item;
+          list-style-type: none;
           padding: 5px 5px 5px 30px;
+
+
+          //----- Sidebar: Menu: Sub Step: Active State ----------------->>
 
           &.active {
             background-color: #D6EEFA;
             border-bottom: 1px solid #B8DFF3;
             border-top: 1px solid #B8DFF3;
-          }
-
-          &.inactive {
-            cursor: pointer;
-            color: #D1D1D1;
-          }
-
-          &.disabled {
-            cursor: default;
-            pointer-events: none;
-          }
-
-          > .current {
-            cursor: pointer;
             color: #363636;
+            cursor: pointer;
           }
+
+
+          //----- Sidebar: Menu: Sub Step: Inactive State ----------------->>
+
+          &.inactive {}
+
+
+          //----- Sidebar: Menu: Sub Step: Complete State ----------------->>
+
+          &.complete {}
+
+
+          //----- Sidebar: Menu: Sub Step: Incomplete State ----------------->>
+
+          &.incomplete {}
         }
-      }
-    }
-
-    .active {
-      .fa.fa-trash {
-        color: #FFFFFF;
-      }
-    }
-
-    i.add-step-or-connection {
-      color: #FFFFFF;
-    }
-
-    .fa.fa-chevron-down, .fa.fa-chevron-right {
-      font-size: x-small;
-      padding-right: 5px;
-      margin-right: 5px;
-    }
-
-    .parent-step {
-      background-color: #E7E7E7;
-      cursor: pointer;
-      display: inline;
-      padding: 8px 100% 8px 8px;
-      text-transform: uppercase;
-
-      &.current {
-        background-color: #158ACC;
-        color: #FFFFFF;
       }
     }
   }

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -72,46 +72,42 @@
         padding: 0;
         width: 32px;
       }
+
+
+      //----- Sidebar: Progress Line: Active State ----------------->>
+
+      &.active {
+        border: 3px solid $pf-blue-400;
+      }
+
+
+      //----- Sidebar: Progress Line: Inactive State ----------------->>
+
+      &.inactive {
+        border: 3px solid #D0D0D0;
+      }
+
+
+      //----- Sidebar: Progress Line: Complete State ----------------->>
+
+      &.complete {
+        .fa {
+          color: $pf-black-900;
+        }
+      }
+
+
+      //----- Sidebar: Progress Line: Incomplete State ----------------->>
+
+      &.incomplete {
+        border: 3px solid #d0d0d0;
+      }
     }
 
     // Vertical Line
 
     .step-line {
       height: 100%;
-    }
-
-
-    //----- Sidebar: Progress Line: Active State ----------------->>
-
-    &.active {
-      .icon {
-        border: 3px solid $pf-blue-400;
-      }
-    }
-
-
-    //----- Sidebar: Progress Line: Inactive State ----------------->>
-
-    &.inactive {
-      .icon {
-        border: 3px solid #D0D0D0;
-      }
-    }
-
-
-    //----- Sidebar: Progress Line: Complete State ----------------->>
-
-    &.complete {
-      .icon {}
-    }
-
-
-    //----- Sidebar: Progress Line: Incomplete State ----------------->>
-
-    &.incomplete {
-      .icon {
-        border: 3px solid #d0d0d0;
-      }
     }
   }
 

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
@@ -159,6 +159,14 @@ export class FlowViewStepComponent extends ChildAwarePage {
     return answer;
   }
 
+  getMenuCompleteClass(state: string) {
+    if (this.getTextClass(state) === 'active') {
+      return 'complete';
+    } else {
+      return 'incomplete';
+    }
+  }
+
   getTextClass(state: string) {
     switch (state) {
       case 'connection-select':

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
@@ -106,7 +106,8 @@ export class FlowViewStepComponent extends ChildAwarePage {
   getParentClass() {
     let clazz = '';
     if (this.getPosition() === this.currentPosition) {
-      clazz = 'current';
+      //clazz = 'current';
+      clazz = 'active';
     }
     return 'parent-step ' + clazz;
   }
@@ -152,8 +153,8 @@ export class FlowViewStepComponent extends ChildAwarePage {
     if ((this.currentState === state || !state) && this.getPosition() === this.currentPosition) {
       answer = 'active';
     }
-    if (this.getTextClass(state) !== 'current') {
-      answer = answer + ' disabled';
+    if (this.getTextClass(state) !== 'active') {
+      answer = answer + ' inactive';
     }
     return answer;
   }
@@ -162,28 +163,28 @@ export class FlowViewStepComponent extends ChildAwarePage {
     switch (state) {
       case 'connection-select':
         if (this.step.connection) {
-          return 'current';
+          return 'active';
         }
         break;
       case 'action-select':
         if (this.step.action) {
-          return 'current';
+          return 'active';
         }
         break;
       case 'action-configure':
       case 'step-configure':
         if (this.step.configuredProperties) {
-          return 'current';
+          return 'active';
         }
         break;
       case 'step-select':
         if (this.step.stepKind) {
-          return 'current';
+          return 'active';
         }
         break;
     }
     if ((this.currentState === state || !state) && this.getPosition() === this.currentPosition) {
-      return 'current';
+      return 'active';
     }
     return '';
   }

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.html
@@ -24,6 +24,7 @@
         <ipaas-integrations-flow-view-step [step]="startConnection()" [position]="0" [currentPosition]="currentPosition" [currentState]="currentState"></ipaas-integrations-flow-view-step>
       </div>
 
+      <!-- First Step: Save or Add Step -->
       <div class="row step-insert" *ngIf="currentState === 'save-or-add-step'" (click)="pop1.toggle()" (mouseover)="pop1.show()" (mouseleave)="pop1.hide()">
           <div class="step-line"></div>
         <template #firstPopTemplate>
@@ -51,7 +52,8 @@
           <div class="step-line"></div>
           <ipaas-integrations-flow-view-step [step]="step" [position]="position + 1" [currentPosition]="currentPosition" [currentState]="currentState"></ipaas-integrations-flow-view-step>
         </div>
-        <!-- Save or Add Step -->
+        
+        <!-- Middle Steps: Save or Add Step -->
         <div class="row step-insert" *ngIf="currentState === 'save-or-add-step'" (click)="pop.toggle()" (mouseover)="pop.show()" (mouseleave)="pop.hide()">
           <div class="step-line"></div>
           <template #firstPopTemplate>

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.scss
@@ -135,12 +135,15 @@ $flow-view-container-min-height: 0;
 
   .steps {
     position: relative;
-    height: 150px;
+    //height: 150px;
+    height: 100%;
     flex-wrap: nowrap;
+    min-height: 250px;
 
     .step-line {
       position: absolute;
-      height: 150px;
+      //height: 150px;
+      height: 100%;
       top: 0;
       left: 46px;
       width: 2px;
@@ -148,6 +151,8 @@ $flow-view-container-min-height: 0;
     }
 
     &.finish {
+      //padding-top: 25px;
+
       .step-line {
         height: 10px;
       }

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -44,10 +44,21 @@
       </h1>
       <p>Now you can add additional connections as well as steps to your integration.</p>
       <p>You can interact with the left hand panel to continue adding steps and connections to your integration as well</p>
-      <div class="blank-slate-pf-secondary-action">
-        <button class="btn btn-default"> Add a Step</button>
+      
+      <!-- First Step -->
+      <div class="blank-slate-pf-secondary-action first-step" *ngIf="getMiddleSteps().length === 0">
+        <p>First Steps</p>
+        <a (click)="insertStepAfter(0)" class="btn btn-default">Add a Step</a>
         &nbsp;&nbsp;&nbsp;
-        <button class="btn btn-default"> Add a Connection</button>
+        <a (click)="insertConnectionAfter(0)" class="btn btn-default">Add a Connection</a>
+      </div>
+      
+      <!-- Middle Steps -->
+      <div class="blank-slate-pf-secondary-action middle-steps" *ngIf="getMiddleSteps().length !== 0">
+        <p>Middle Steps</p>
+        <a (click)="insertStepAfter(position + 1)" class="btn btn-default">Add a Step</a>
+        &nbsp;&nbsp;&nbsp;
+        <a (click)="insertConnectionAfter(position + 1)" class="btn btn-default">Add a Connection</a>
       </div>
     </div>
   </div>

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -43,7 +43,7 @@
         Add to Integration
       </h1>
       <p>Now you can add additional connections as well as steps to your integration.</p>
-      <p>You can interact with the left hand panel to continue adding steps and connections to your integration as well</p>
+      <p>You can interact with the left hand panel to continue adding steps and connections to your integration as well.</p>
       
       <!-- First Step -->
       <div class="blank-slate-pf-secondary-action first-step" *ngIf="getMiddleSteps().length === 0">

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -47,7 +47,6 @@
       
       <!-- First Step -->
       <div class="blank-slate-pf-secondary-action first-step" *ngIf="getMiddleSteps().length === 0">
-        <p>First Steps</p>
         <a (click)="insertStepAfter(0)" class="btn btn-default">Add a Step</a>
         &nbsp;&nbsp;&nbsp;
         <a (click)="insertConnectionAfter(0)" class="btn btn-default">Add a Connection</a>
@@ -55,7 +54,6 @@
       
       <!-- Middle Steps -->
       <div class="blank-slate-pf-secondary-action middle-steps" *ngIf="getMiddleSteps().length !== 0">
-        <p>Middle Steps</p>
         <a (click)="insertStepAfter(position + 1)" class="btn btn-default">Add a Step</a>
         &nbsp;&nbsp;&nbsp;
         <a (click)="insertConnectionAfter(position + 1)" class="btn btn-default">Add a Connection</a>

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -7,6 +7,9 @@ import { IntegrationStore } from '../../../store/integration/integration.store';
 import { CurrentFlow, FlowEvent } from '../current-flow.service';
 import { FlowPage } from '../flow-page';
 import { Integration, Step, TypeFactory } from '../../../model';
+import { log, getCategory } from '../../../logging';
+
+const category = getCategory('IntegrationsCreatePage');
 
 @Component({
   selector: 'ipaas-integrations-save-or-add-step',
@@ -25,19 +28,9 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
   ) {
     super(currentFlow, route, router);
   }
-
-  goBack() { /* this should be a no-op */ }
-
-  save() {
-    this.currentFlow.integration.statusType = 'Deactivated';
-    this.doSave();
+  get currentStep() {
+    return this.getCurrentStep();
   }
-
-  saveAndPublish() {
-    this.currentFlow.integration.statusType = 'Activated';
-    this.doSave();
-  }
-
   doSave() {
     if (!this.currentFlow.integration.name || this.currentFlow.integration.name === '') {
       this.router.navigate(['integration-basics'], { relativeTo: this.route.parent });
@@ -55,6 +48,83 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
     });
   }
 
+  getCurrentPosition(route: ActivatedRoute = this.route): number {
+    const child = route.firstChild;
+    if (child && child.snapshot) {
+      const path = child.snapshot.url;
+      // log.debugc(() => 'path from root: ' + path, category);
+      try {
+        const position = path[1].path;
+        return +position;
+      } catch (error) {
+        return -1;
+      }
+    } else {
+      // log.debugc(() => 'no current child', category);
+      return undefined;
+    }
+  }
+
+  getCurrentStep(route: ActivatedRoute = this.route) {
+    return this.currentFlow.getStep(this.getCurrentPosition(route));
+  }
+
+  goBack() { /* this should be a no-op */ }
+
+  handleFlowEvent(event: FlowEvent) {
+    switch (event.kind) {
+      case 'integration-updated':
+        this.validateFlow();
+        break;
+    }
+  }
+
+  insertStepAfter(position: number) {
+    const target = position + 1;
+    const step = TypeFactory.createStep();
+    this.currentFlow.steps.splice(target, 0, step);
+    this.router.navigate(['step-select', target], { relativeTo: this.route });
+  }
+
+  insertConnectionAfter(position: number) {
+    const target = position + 1;
+    const step = TypeFactory.createStep();
+    step.stepKind = 'endpoint';
+    this.currentFlow.steps.splice(target, 0, step);
+    this.router.navigate(['connection-select', target], { relativeTo: this.route });
+  }
+
+  save() {
+    this.currentFlow.integration.statusType = 'Deactivated';
+    this.doSave();
+  }
+
+  saveAndPublish() {
+    this.currentFlow.integration.statusType = 'Activated';
+    this.doSave();
+  }
+
+  startConnection() {
+    return this.currentFlow.getStep(this.firstPosition());
+  }
+
+  endConnection() {
+    return this.currentFlow.getStep(this.lastPosition());
+  }
+
+  firstPosition() {
+    return this.currentFlow.getFirstPosition();
+  }
+
+  lastPosition() {
+    return this.currentFlow.getLastPosition();
+  }
+
+  getMiddleSteps() {
+    //log.debugc(() => 'this.currentFlow.getMiddleSteps().length: ' + this.currentFlow.getMiddleSteps().length);
+    return this.currentFlow.getMiddleSteps();
+  }
+
   validateFlow() {
     if (this.currentFlow.getStartConnection() === undefined) {
       this.router.navigate(['connection-select', this.currentFlow.getFirstPosition()], { relativeTo: this.route.parent });
@@ -63,14 +133,6 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage implements OnIn
     if (this.currentFlow.getEndConnection() === undefined) {
       this.router.navigate(['connection-select', this.currentFlow.getLastPosition()], { relativeTo: this.route.parent });
       return;
-    }
-  }
-
-  handleFlowEvent(event: FlowEvent) {
-    switch (event.kind) {
-      case 'integration-updated':
-        this.validateFlow();
-        break;
     }
   }
 


### PR DESCRIPTION
## Changes
- Add space between start and finish icons, require that line take up the full height of the division as it grows and shrinks, with a minimum height of 200px always being required.
- Refactor SCSS for `flow-view-step.component.scss` to accommodate for active/inactive and complete/incomplete state classes.
- Add method (not functional, but that's for a separate PR) to determine whether section is complete or incomplete.
- Fix bug that was causing icons to all have `inactive` states. re #305
- 'Add Step' and 'Add Connection' buttons on first-time landing page when saving or adding a step are functional, though redirect does not work properly. re #314 

## Screenshots

<img width="1440" alt="screenshot 2017-03-24 18 12 01" src="https://cloud.githubusercontent.com/assets/3844502/24315708/0dade966-10bf-11e7-885a-d535b3bf8647.png">


## To Do

- Determine when a Step is complete and assign appropriate class.
- Force tooltip to remain open on first time user is prompted to add a step or connection (should this be a locally stored var to reference from other places?).
- Fix redirect issue with buttons on Save or Add Step/Connection page.