### PR TITLE
Fix typo in user's alias

### DIFF
--- a/e2e/data/users.example.json
+++ b/e2e/data/users.example.json
@@ -1,6 +1,6 @@
 {
   "users": {
-    "camila": {
+    "camilla": {
       "username": "github-login",
       "password": "github-password"
     }


### PR DESCRIPTION
Just small typo fix in `users.json.example` to link the narrative's Camilla to e2e's Camilla.

cc @jludvice @kahboom 