### PR TITLE
[relates #295] Fix active inactive round box

### DIFF
--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -91,7 +91,6 @@
       //----- Sidebar: Progress Line: Complete State ----------------->>
 
       &.complete {
-        border: 3px solid $pf-blue-400;
         .fa {
           color: $pf-black-900;
         }
@@ -101,7 +100,9 @@
       //----- Sidebar: Progress Line: Incomplete State ----------------->>
 
       &.incomplete {
-        border: 3px solid #d0d0d0;
+        .fa {
+          color: #D1D1D1;
+        }
       }
     }
 


### PR DESCRIPTION
border color defined in `.complete` and `.incomplete` classes was overriding color specified by `.active` and `.inactive` css classes.

![active-inactive](https://cloud.githubusercontent.com/assets/8707241/24409250/f69729a4-13cf-11e7-895e-1634b221a46f.png)

This way 
- completed/incompleted icon in the middle has black/gray color
- active inactive round is blue / gray

Is this change ok @kahboom ?