### PR TITLE
Externalize the datamapper config

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -169,6 +169,9 @@ export function restangularProviderConfigurer(restangularProvider: any, config: 
       deps: [ConfigService, OAuthService, UserService, NgZone],
       multi: true,
     },
+    ConfigService,
+    OAuthService,
+    UserService,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/config.service.ts
+++ b/src/app/config.service.ts
@@ -15,12 +15,21 @@ const defaults = environment.config;
 
 const defaultConfigJson = '/config.json';
 
+let instance: ConfigService = undefined;
+
 @Injectable()
 export class ConfigService {
 
   private settingsRepository: any = defaults;
 
-  constructor(private _http: Http) { }
+  constructor(private _http: Http) {
+    // TODO hmm, this should be a singleton but it isn't acting like one, let's force it...
+    if (!instance) {
+      instance = this;
+    } else {
+      this.settingsRepository = instance.getSettings();
+    }
+  }
 
   load(configJson: string = defaultConfigJson): Promise<ConfigService> {
     return this._http.get(configJson).map(res => res.json())

--- a/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
@@ -13,6 +13,8 @@ import { MappingManagementService } from 'ipaas.data.mapper';
 
 import { DataMapperAppComponent } from 'ipaas.data.mapper';
 
+import { ConfigService } from '../../../config.service';
+
 import { CurrentFlow, FlowEvent } from '../current-flow.service';
 import { FlowPage } from '../flow-page';
 
@@ -25,6 +27,7 @@ const MAPPING_KEY = 'atlasmapping';
       <data-mapper #dataMapperComponent [cfg]="cfg"></data-mapper>
     </div>
   `,
+  providers: [ConfigService],
 })
 export class DataMapperHostComponent extends FlowPage implements OnInit, OnDestroy {
 
@@ -58,8 +61,17 @@ export class DataMapperHostComponent extends FlowPage implements OnInit, OnDestr
     public documentService: DocumentManagementService,
     public mappingService: MappingManagementService,
     public errorService: ErrorHandlerService,
+    public configService: ConfigService,
   ) {
     super(currentFlow, route, router);
+    const settings = configService.getSettings();
+    console.log('Settings: ', settings);
+    try {
+      this.cfg.baseJavaServiceUrl = configService.getSettings('datamapper', 'baseJavaServiceUrl') || this.cfg.baseJavaServiceUrl;
+      this.cfg.baseMappingServiceUrl = configService.getSettings('datamapper', 'baseMappingServiceUrl') || this.cfg.baseMappingServiceUrl;
+    } catch (err) {
+      // run with defaults
+    }
   }
 
 

--- a/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
@@ -64,8 +64,6 @@ export class DataMapperHostComponent extends FlowPage implements OnInit, OnDestr
     public configService: ConfigService,
   ) {
     super(currentFlow, route, router);
-    const settings = configService.getSettings();
-    console.log('Settings: ', settings);
     try {
       this.cfg.baseJavaServiceUrl = configService.getSettings('datamapper', 'baseJavaServiceUrl') || this.cfg.baseJavaServiceUrl;
       this.cfg.baseMappingServiceUrl = configService.getSettings('datamapper', 'baseMappingServiceUrl') || this.cfg.baseMappingServiceUrl;

--- a/src/config.json.example
+++ b/src/config.json.example
@@ -1,6 +1,10 @@
 {
   "apiEndpoint": "http://localhost:8080/api/v1",
   "title": "Red Hat iPaaS",
+  "datamapper": {
+    "baseJavaServiceUrl": "https://localhost:8585/v2/atlas/java/",
+    "baseMappingServiceUrl": "https://localhost:8585/v2/atlas/"
+  },
   "oauth": {
     "clientId": "ipaas-ui",
     "scopes": [],

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,6 +8,10 @@ export const environment = Object.freeze({
   config: {
     apiEndpoint: 'http://localhost:8080/api/v1',
     title: 'DEVELOPMENT - Red Hat iPaaS',
+    datamapper: {
+      baseJavaServiceUrl: 'https://localhost:8585/v2/atlas/java/',
+      baseMappingServiceUrl: 'https://localhost:8585/v2/atlas/',
+    },
     oauth: {
       clientId: 'ipaas-ui',
       scopes: [],


### PR DESCRIPTION
This makes the settings in `config.json` take precedence for the data mapper endpoints.  So you'll need a `config.json` that looks like this for staging:

```
{
  "apiEndpoint": "https://ipaas-staging.b6ff.rh-idev.openshiftapps.com/api/v1",
  "title": "Red Hat iPaaS",
  "datamapper": {
    "baseJavaServiceUrl": "https://ipaas-staging.b6ff.rh-idev.openshiftapps.com/v2/atlas/java/",
    "baseMappingServiceUrl": "https://ipaas-staging.b6ff.rh-idev.openshiftapps.com/v2/atlas/"
  },
  "oauth": {
    "clientId": "ipaas-ui",
    "scopes": [],
    "oidc": true,
    "hybrid": true,
    "issuer": "https://ipaas-staging.b6ff.rh-idev.openshiftapps.com/auth/realms/ipaas"
  }
}
```

@jimmidyson how does this get picked up in the staging instance?  Want to be sure we get that working too but I couldn't tell from the CI config.

Probably worth holding off merging this until the above question is answered.