### PR TITLE
Add cmd e2e:xvfb to execute e2e tests in container

### DIFF
--- a/e2e-xvfb.sh
+++ b/e2e-xvfb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+nohup /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x24 &
+export DISPLAY=:99
+yarn
+npm rebuild node-sass
+exec yarn e2e:ipaas-qe

--- a/e2e-xvfb.sh
+++ b/e2e-xvfb.sh
@@ -3,5 +3,5 @@
 nohup /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x24 &
 export DISPLAY=:99
 yarn
-npm rebuild node-sass
+yarn webdriver-manager update
 exec yarn e2e:ipaas-qe

--- a/e2e/Readme.md
+++ b/e2e/Readme.md
@@ -13,11 +13,18 @@ launch tests using local dev server `http://localhost:4200`
 yarn e2e
 ```
 
-alternatively launch tests using remote web ui
+launch tests using remote web ui
 ```bash
 export IPAAS_UI_URL='https://ipaas-qe.b6ff.rh-idev.openshiftapps.com/'
 yarn e2e:ipaas-qe
 ```
+
+alternatively launch tests in Docker container with Xvfb
+```bash
+export IPAAS_UI_URL='https://ipaas-qe.b6ff.rh-idev.openshiftapps.com/'
+yarn e2e:xvfb
+```
+
 
 ## Launch subset of cucumber tests
 Tests (`*.feature) files can have something like java annotations.

--- a/e2e/conf/protractor.base.conf.js
+++ b/e2e/conf/protractor.base.conf.js
@@ -18,7 +18,10 @@ exports.config = {
     testPath +  '/**/*.feature'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    'chromeOptions': {
+      'args': ['--no-sandbox']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pree2e": "webdriver-manager update",
     "e2e": "better-npm-run e2e:local",
     "e2e:ipaas-qe": "better-npm-run e2e:ipaas-qe",
+    "e2e:xvfb": "docker run -e IPAAS_UI_URL=$IPAAS_UI_URL --rm -v `pwd`:/ipaas-ui:z -w /ipaas-ui -u `id -u` docker.io/rhipaas/karma-xvfb ./e2e-xvfb.sh",
     "sw": "sw-precache --root=dist --config=sw-precache-config.js",
     "docker:build": "yarn ng build -- --aot --prod && docker build -t rhipaas/ipaas-ui:latest ."
   },


### PR DESCRIPTION
Related to #93. This PR adds possibility to execute e2e tests from Docker container.  