### PR TITLE
Run the change detector after we initialize the mapper component

### DIFF
--- a/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data.mapper.example.host.component.ts
@@ -149,11 +149,13 @@ export class DataMapperHostComponent extends FlowPage implements OnInit, OnDestr
         this.cfg.pomPayload = pom;
         this.initializationService.initialize();
         this.initialized = true;
+        this.detector.detectChanges();
       }, (err) => {
         // do our best I guess
         log.warnc(() => 'failed to fetch pom: ', JSON.parse(err), category);
         this.initializationService.initialize();
         this.initialized = true;
+        this.detector.detectChanges();
       });
   }
 


### PR DESCRIPTION
Just a little fix that ensures the data mapper shows up on the page, noticed when investigating updating the component to the latest commit.