### PR TITLE
Create Integration: Sidebar Fixes

### DIFF
--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -50,14 +50,15 @@
     text-align: center;
 
     .fa {
-      color: #D1D1D1;
+      color: $pf-black-300;
       font-size: x-large;
     }
 
     .icon {
       -moz-border-radius: 100px;
       border-radius: 100px;
-      border: 3px solid #d0d0d0;
+      //border: 3px solid #d0d0d0;
+      border: 3px solid $pf-black-300;
       padding: 11px;
       width: 55px;
       height: 55px;
@@ -65,12 +66,18 @@
 
       &.add-step-or-connection {
         background-color: #FFFFFF;
-        border: 10px solid $pf-blue-400;
+        //border: 10px solid $pf-blue-400;
+        border: 12px solid #0088ce;
+        padding: 5px 0px;
         border-radius: 100px;
         height: 33px;
         margin: 11px;
-        padding: 0;
+        //padding: 0;
         width: 32px;
+
+        &.active {
+          border: 12px solid #0088ce;
+        }
       }
 
 
@@ -149,7 +156,8 @@
       //----- Sidebar: Menu: Parent Step ----------------->>
 
       .parent-step {
-        background-color: #E7E7E7;
+        //background-color: #E7E7E7;
+        background-color: $pf-black-300;
         cursor: pointer;
         display: inline;
         padding: 8px 100% 8px 8px;

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../scss/colors';
+
 $flow-view-container-min-height: 0;
 
 /deep/ .popover {
@@ -112,9 +114,6 @@ $flow-view-container-min-height: 0;
 
     a {
       text-decoration: none;
-
-      &:hover {
-      }
     }
 
     .popover-body {
@@ -141,7 +140,8 @@ $flow-view-container-min-height: 0;
       top: 0;
       left: 46px;
       width: 2px;
-      background-color: #d4d4d4;
+      //background-color: #d4d4d4;
+      background-color: $pf-black-300;
     }
   }
 


### PR DESCRIPTION
## Changes
- Fixed sidebar donut thing-y in the Create an Integration sidebar.
- Darkened the background of the grayed out menu items on the left hand sidebar.
- Darkened the entire diagram / progress line on the left hand side.

## To Do
- Change hover state background for list of Steps to be blue instead of gray.
- Change pointer for each step.

## Screenshots

<img width="1440" alt="screenshot 2017-04-12 23 18 21" src="https://cloud.githubusercontent.com/assets/3844502/24988847/9cba0614-1fd6-11e7-9903-fc09084d2c5a.png">
