### PR TITLE
[E2E] Handle Keycloak first time visit page in E2E tests

### DIFF
--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -135,25 +135,21 @@ export class AppPage {
     // wait either for login page or loaded ipaas app
     await P.race([
       browser.wait(ExpectedConditions.presenceOf(this.rootElement), 1000, 'ipaas root element - assuming we are already logged in'),
-      browser.wait(ExpectedConditions.presenceOf(element(by.css('input'))), 1000, 'Some input field - assuming we are on login page'),
+      browser.wait(ExpectedConditions.presenceOf(element(by.css('input#login_field'))), 1000, 'Github login page' ).then(() => {
+        log.info('GitHub login page');
+        return new GithubLogin().login(user);
+      }),
     ]);
 
-    let url = await this.currentUrl();
+    await P.race([
+      browser.wait(ExpectedConditions.presenceOf(this.rootElement), 1000, 'ipaas root element - assuming we are already logged in'),
+      browser.wait(ExpectedConditions.presenceOf(element(by.css('input#firstName'))), 1000, 'Keycloack login page' ).then(() => {
+        log.info('Keycloak first time visit page');
+        return new KeycloakDetails().submitUserDetails(user.userDetails);
+      }),
+    ]);
 
-    if (contains(url, 'github')) {
-      // we need to login on github
-      await new GithubLogin().login(user);
-    } else if (contains(url, browser.baseUrl)) {
-      // pass - we're already logged in
-    } else {
-      return P.reject(`Unsupported login page ${url}`);
-    }
-    url = await this.currentUrl();
-    if (contains(url, 'first-broker-login')) {
-      await new KeycloakDetails().submitUserDetails(user.userDetails);
-    }
     browser.waitForAngularEnabled(true);
-
     return this.goToUrl(AppPage.baseurl);
   }
 

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -1,9 +1,9 @@
 import { by, browser, element, ExpectedConditions, ElementFinder } from 'protractor';
 import * as webdriver from 'selenium-webdriver';
 import { Promise as P } from 'es6-promise';
-import { User } from './common/common';
+import { User, UserDetails } from './common/common';
 import { contains } from './common/world';
-import { GithubLogin } from './login/login.po';
+import { GithubLogin, KeycloakDetails } from './login/login.po';
 import { log } from '../src/app/logging';
 import * as jQuery from 'jquery';
 import WebElement = webdriver.WebElement;
@@ -138,7 +138,7 @@ export class AppPage {
       browser.wait(ExpectedConditions.presenceOf(element(by.css('input'))), 1000, 'Some input field - assuming we are on login page'),
     ]);
 
-    const url = await this.currentUrl();
+    let url = await this.currentUrl();
 
     if (contains(url, 'github')) {
       // we need to login on github
@@ -148,7 +148,12 @@ export class AppPage {
     } else {
       return P.reject(`Unsupported login page ${url}`);
     }
+    url = await this.currentUrl();
+    if (contains(url, 'first-broker-login')) {
+      await new KeycloakDetails().submitUserDetails(user.userDetails);
+    }
     browser.waitForAngularEnabled(true);
+
     return this.goToUrl(AppPage.baseurl);
   }
 

--- a/e2e/common/common.steps.ts
+++ b/e2e/common/common.steps.ts
@@ -1,12 +1,12 @@
 /**
  * Created by jludvice on 8.3.17.
  */
-import { CallbackStepDefinition } from 'cucumber';
+import { CallbackStepDefinition, TableDefinition } from 'cucumber';
 import { browser } from 'protractor';
 import { binding, given, then, when } from 'cucumber-tsflow';
 import { Promise as P } from 'es6-promise';
 import { expect, World } from './world';
-import { User } from './common';
+import { User, UserDetails } from './common';
 import { log } from '../../src/app/logging';
 /**
  * Generic steps that can be used in various features
@@ -21,14 +21,14 @@ class CommonSteps {
 
   @given(/^credentials for "([^"]*)"$/)
   public loadCredentials(alias: string, callback: CallbackStepDefinition): void {
-    this.world.user = new User(alias.toLowerCase(), 'asdfadf');
+    this.world.user = new User(alias.toLowerCase(), 'asdfadf', null);
     log.info(`using alias ${alias} with login ${this.world.user.username}`);
     callback();
   }
 
   @when(/^"(\w+)" logs into the iPaaS.*$/i)
   public login(alias: string): P<any> {
-    this.world.user = new User(alias.toLowerCase(), 'asdfadf');
+    this.world.user = new User(alias.toLowerCase(), 'asdfadf', null);
     // return this.app.login(this.world.user);
     return this.world.app.login(this.world.user);
   }

--- a/e2e/common/common.ts
+++ b/e2e/common/common.ts
@@ -5,9 +5,10 @@ export class User {
   description: string;
   username: string;
   password: string;
+  userDetails: UserDetails;
 
 
-  constructor(alias: string, description: string) {
+  constructor(alias: string, description: string, userDetails: UserDetails) {
     this.alias = alias;
     this.description = description;
 
@@ -22,6 +23,11 @@ export class User {
       this.username = envUsername;
       this.password = envPassword;
     }
+    if (userDetails === null) {
+      this.userDetails = new UserDetails(`${this.alias}@example.com`, 'FirstName', 'LastName');
+    } else {
+      this.userDetails = userDetails;
+    }
   }
 
 
@@ -29,6 +35,18 @@ export class User {
     return `User{alias=${this.alias}, login=${this.username}}`;
   }
 
+}
+
+export class UserDetails {
+  email: string;
+  firstName: string;
+  lastName: string;
+
+  constructor(email: string, firstName: string, lastName: string) {
+    this.email = email;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
 }
 
 /**

--- a/e2e/connections/connections.feature
+++ b/e2e/connections/connections.feature
@@ -15,7 +15,7 @@ Feature: Connections smoke test
 
   Scenario: Create connection happy path
     When "Camilla" navigates to the "Connections" page
-    And click on the "Create" button
+    And click on the "Create Connection" button
     And Camilla selects the "Twitter" connection
     Then she is presented with the "Validate" button
 
@@ -29,4 +29,3 @@ Feature: Connections smoke test
 
     When Camilla selects the "my sample twitter connection" connection
     Then Camilla is presented with "my sample twitter connection" connection details
-

--- a/e2e/login/login.feature
+++ b/e2e/login/login.feature
@@ -5,13 +5,9 @@ Feature: First pass at login, homepage, connections
   Camila (citizen developer) first explores
 
   Background:
-    Given credentials for "camilla"
-
+    Given credentials for "Camilla"
 
   Scenario: User Camila logins
     When "Camilla" logs into the iPaaS
     And "Camilla" navigate to the "Connections" page
     Then she is presented with at least "2" connections
-
-
-

--- a/e2e/login/login.po.ts
+++ b/e2e/login/login.po.ts
@@ -1,4 +1,4 @@
-import { User } from '../common/common';
+import { User, UserDetails } from '../common/common';
 import { by, element, browser, ExpectedConditions } from 'protractor';
 import { contains, P } from '../common/world';
 import { log } from '../../src/app/logging';
@@ -39,5 +39,32 @@ export class GithubLogin implements LoginPage {
     } else {
       return P.resolve();
     }
+  }
+}
+
+export class KeycloakDetails {
+
+  loginSelector = 'input#username';
+  emailSelector = 'input#email';
+  firstNameSelector = 'input#firstName';
+  lastNameSelector = 'input#lastName';
+  submitSelector = '#kc-form-buttons > input.btn.btn-primary.btn-lg';
+
+  async submitUserDetails(userDetails: UserDetails): P<any> {
+    const login = element(by.css(this.loginSelector));
+    const email = element(by.css(this.emailSelector));
+    const firstName = element(by.css(this.firstNameSelector));
+    const lastName = element(by.css(this.lastNameSelector));
+    const submit = element(by.css(this.submitSelector));
+
+    browser.wait(ExpectedConditions.presenceOf(login), 10000, 'waiting for Keycloak login field');
+    email.getWebElement().sendKeys(userDetails.email);
+    firstName.getWebElement().sendKeys(userDetails.firstName);
+    lastName.getWebElement().sendKeys(userDetails.lastName);
+    await submit.getWebElement().click();
+
+    const url = await browser.getCurrentUrl();
+    log.info(`Keycloak login, current url: ${url}`);
+    return P.resolve();
   }
 }


### PR DESCRIPTION
Related to #513. I've tried to implement submitting details for first time visit page.

It would be better to have details in gherkin data table, but I wasn't able to get it working properly, probably my silly mistake. I think we can improve it later and go on just with opinionated defaults right now. 

Where it gets interesting is [this part](https://github.com/redhat-ipaas/ipaas-ui/compare/master...dsimansk:e2e-fixes?expand=1#diff-6fe650a8e21fe8d744c835bf070922f3R152). Would it be better to react on `waitForAngularEnabled` error and kick-in filling the form afterwards?
