### PR TITLE
Aesthetic changes in Dashboard, Connection Detail, and Integration List

### DIFF
--- a/src/app/connections/view-toolbar/view-toolbar.component.scss
+++ b/src/app/connections/view-toolbar/view-toolbar.component.scss
@@ -7,5 +7,9 @@ ol {
 
   &.breadcrumb {
     padding: 0;
+
+    li {
+      cursor: default;
+    }
   }
 }

--- a/src/app/connections/view/view.component.html
+++ b/src/app/connections/view/view.component.html
@@ -17,8 +17,8 @@
           <h2 class="card-pf-title">{{name}}</h2>
         </div>
         <div class="description">{{description}}</div>
-        <div>
-          <span class="badge"
+        <div class="tags">
+          <span class="label label-primary"
                 *ngFor="let tag of tagsArray">{{tag}}</span>
         </div>
       </div>

--- a/src/app/connections/view/view.component.scss
+++ b/src/app/connections/view/view.component.scss
@@ -1,11 +1,27 @@
 @import '../../../scss/colors';
 
 .connections-view {
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // COMMON ACROSS ALL CONNECTION STATES
+  // These classes apply to the 'Create', 'Edit', and 'View' states.
+  ////////////////////////////////////////////////////////////////////////////////
+
+
   .card-pf {
     .card-pf-body {
       .fa {
         font-size: x-large;
       }
+    }
+  }
+
+  .tags {
+    margin: 20px 0;
+
+    .label {
+      margin-right: 5px;
     }
   }
 
@@ -106,20 +122,12 @@
 
   //----- Edit & Configure a Connection - Specific Overrides to the Connection List ----------------->>
 
-  &.edit {
-    //padding-top: 20px;
-    //padding-bottom: 40px;
-
-    .card-pf-body {
-      //background: #FFFFFF;
-    }
-  }
+  &.edit {}
 
 
   //----- View a Connection - Specific Overrides to the Connection List ----------------->>
 
   &.view {
-    //background: $pf-black-200;
-    //padding: 20px 40px;
+    cursor: default;
   }
 }

--- a/src/app/dashboard/integrations.component.html
+++ b/src/app/dashboard/integrations.component.html
@@ -87,38 +87,37 @@
 
                 <div class="col-xs-3 icons"
                      (click)="goto(integration)">
-                  <div class="list-view-pf-left">
-                    <!--
-                    <span [class]="'fa ' + getStartIcon(integration) + ' list-view-pf-icon-sm'"></span>
-                    <span class="fa fa-angle-right"></span>
-                    <span [class]="'fa ' + getFinishIcon(integration) + ' list-view-pf-icon-sm'"></span>
-                    -->
+                  <div class="col-xs-12">
                     <span class="image-icon"
                           *ngIf="getStart(integration).connection">
-                      <img src="../../../assets/icons/{{ getStart(integration).connection.connectorId }}.integration.png">
+                      <img src="../../../assets/icons/{{ getStart(integration).connection.connectorId }}.integration.png"
+                           class="start">
                     </span>
                     <span class="fa fa-angle-right"></span>
                     <span class="image-icon"
                           *ngIf="getFinish(integration).connection">
-                      <img src="../../../assets/icons/{{ getFinish(integration).connection.connectorId }}.integration.png">
+                      <img src="../../../assets/icons/{{ getFinish(integration).connection.connectorId }}.integration.png"
+                           class="end">
                     </span>
                   </div>
                 </div>
 
                 <!-- Name -->
 
-                <div class="col-xs-4 name"
+                <div class="col-xs-7 name"
                      (click)="goto(integration)">
                   {{ integration.name }}
                 </div>
 
                 <!-- Uses -->
 
+                <!--
                 <div class="col-xs-3 uses"
                      (click)="goto(integration)">
                   <p>{{ integration.timesUsed || 0 }} uses
                   </p>
                 </div>
+                -->
 
                 <!-- Status -->
 
@@ -244,16 +243,16 @@
                    *ngIf="i<5"
                    (click)="goto(integration)">
                 <div class="col-xs-5">
-                  Updated: <a [routerLink]=" ['/integrations/edit', integration.id, 'save-or-add-step'] ">
+                  <a [routerLink]=" ['/integrations/edit', integration.id, 'save-or-add-step'] ">
                   {{ integration.name }}
                 </a>
                 </div>
-                <div class="col-xs-4">
+                <div class="col-xs-3">
                   <span [class]="'label ' + getLabelClass(integration)">
                   {{ getStatusText(integration) }}
                 </span>
                 </div>
-                <div class="col-xs-3">
+                <div class="col-xs-4">
                   {{ integration.lastUpdated | date:'d MMM HH:MM' }}
                 </div>
               </div>

--- a/src/app/dashboard/integrations.component.scss
+++ b/src/app/dashboard/integrations.component.scss
@@ -86,6 +86,7 @@
           canvas {
             width: 80% !important;
             height: 80% !important;
+            z-index: 50;
           }
 
           .total-count {
@@ -142,7 +143,7 @@
     .recent-updates {
       .update {
         border-bottom: 1px solid $pf-black-200;
-        cursor: default;
+        cursor: pointer;
         padding: 10px 0;
 
         &:hover {
@@ -161,6 +162,12 @@
     //----- Top 5 Integrations ----------------->>
 
     .top-integrations {
+      .card-pf-heading-details {
+        float: right;
+        font-size: 12px;
+        margin-bottom: 0;
+      }
+
       .integration {
         cursor: pointer;
         padding: 15px;
@@ -197,22 +204,26 @@
         }
 
         .icons {
-          padding: 0 0 0 6px;
+          overflow: visible;
+          margin: 0;
+          padding: 0;
+          text-align: center;
 
-          .list-view-pf-left {
-            display: table-cell;
-            padding-right: 0;
-            text-align: center;
-            vertical-align: top;
+          .col-xs-12 {
+            padding: 0;
 
-            .fa:first-child, .fa-angle-right {
-              margin-right: 15px;
-            }
+            .image-icon {
+              img {
+                display: inline-block;
 
-            .fa.fa-angle-right {
-              font-size: 18px;
-              margin: 0;
-              padding: 0 10px;
+                &.start {
+                  padding-right: 10px;
+                }
+
+                &.end {
+                  padding-left: 10px;
+                }
+              }
             }
           }
         }

--- a/src/app/integrations/list/list.component.html
+++ b/src/app/integrations/list/list.component.html
@@ -75,12 +75,12 @@
            (click)="goto(integration)">
 
         <!-- Name -->
-        <div class="col-xs-4 name">
+        <div class="col-xs-5 name">
           {{ integration.name }}
         </div>
 
         <!-- Description -->
-        <div class="col-xs-8 description">
+        <div class="col-xs-7 description">
           <div class="list-group-item-text">
             {{ integration.description }}
           </div>


### PR DESCRIPTION
## Changes

- Dashboard: Spaced out column distribution of Recent Updates and Top 5 Integrations widgets.
- Dashboard: Hid 'uses' column, as we will not be using it.
- Dashboard: Cursor change to `pointer` for Recent Updates, as these are now actionable rows.
- Dashboard: Update tooltip on Integration Board chart to overlay the total Integration count.
- Connection Detail: Updated Tags to use `labels` rather than badges. Spaced them out.
- Connection Detail: Entire page, including toolbar, should now use `cursor: default` unless it's an anchor, to make it appear more polished and final.
- Integration List: Distributed columns more evenly to give additional space to names.

## Screenshots

### Dashboard

Column spacing for Recent Updates and Top 5 Integrations widgets.

<img width="1285" alt="screenshot 2017-04-25 14 45 02" src="https://cloud.githubusercontent.com/assets/3844502/25402671/78da4fce-29c7-11e7-8b38-2878cb56f2af.png">

**Before: Swallowed up text**

<img width="1048" alt="screenshot 2017-04-25 14 55 16" src="https://cloud.githubusercontent.com/assets/3844502/25402706/8f2f074c-29c7-11e7-8628-911857a86ec1.png">

<img width="885" alt="screenshot 2017-04-25 14 54 59" src="https://cloud.githubusercontent.com/assets/3844502/25402678/7edeedb2-29c7-11e7-9217-bcb3e650c68e.png">


**After: No more swallowing!**

<img width="1038" alt="screenshot 2017-04-25 14 54 48" src="https://cloud.githubusercontent.com/assets/3844502/25402713/967d919e-29c7-11e7-9ee1-01daff93df7b.png">

<img width="877" alt="screenshot 2017-04-25 14 54 38" src="https://cloud.githubusercontent.com/assets/3844502/25402717/99bdcf9a-29c7-11e7-9b68-c667ecec64d7.png">

### Connection Details

<img width="1281" alt="screenshot 2017-04-25 14 44 23" src="https://cloud.githubusercontent.com/assets/3844502/25402643/5ddb74fa-29c7-11e7-90ac-852fc5ccc0e4.png">

### Integration List

<img width="1282" alt="screenshot 2017-04-25 14 44 46" src="https://cloud.githubusercontent.com/assets/3844502/25402653/65310742-29c7-11e7-97fa-3d6775f7b768.png">
